### PR TITLE
KMS Names: Allow for explicitly specifying the kms key/ring names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -253,12 +253,12 @@ resource "google_container_node_pool" "build" {
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  name     = var.cluster_name
+  name     = var.kms_name == null ? var.cluster_name : var.kms_name
   location = local.region
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
-  name            = var.cluster_name
+  name            = var.kms_name == null ? var.cluster_name : var.kms_name
   key_ring        = google_kms_key_ring.key_ring.self_link
   rotation_period = "86400s"
   purpose         = "ENCRYPT_DECRYPT"

--- a/variables.tf
+++ b/variables.tf
@@ -74,10 +74,22 @@ variable "compute_node_type" {
   default = "n1-standard-1"
 }
 
+variable "enable_vertical_pod_autoscaling" {
+  type        = bool
+  default     = true
+  description = "Enable GKE vertical scaling"
+}
+
 variable "gke_version" {
   type        = string
   default     = "1.14.6-gke.13"
   description = "GKE K8s version for both master and node pools"
+}
+
+variable "kms_name" {
+  type        = string
+  default     = null
+  description = "KMS Ring and Crypto key name - defaults to cluster name"
 }
 
 variable "location" {
@@ -121,10 +133,4 @@ variable "platform_nodes_ssd_gb" {
 variable "platform_node_type" {
   type    = string
   default = "n1-standard-8"
-}
-
-variable "enable_vertical_pod_autoscaling" {
-  type        = bool
-  default     = true
-  description = "Enable GKE vertical scaling"
 }


### PR DESCRIPTION
# Example
```
export TF_VAR_cluster_name=test5
export TF_VAR_kms_name=test5-key2
```