### PR TITLE
E2E Fix: Retry Terraform Destroy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
       - run:
           name: Terraform destroy
-          command: terraform destroy -auto-approve
+          command: terraform destroy -auto-approve || (sleep 1m && terraform destroy -auto-approve)
           when: always
 
       - run:


### PR DESCRIPTION
Often after being created, the GKE cluster fails to be destroyed. I think this is due to an eventual-consistency issue on GCP's side. 

This is an attempt to fix failed `terraform destroy` by retrying after a small 1 minute delay. This hopefully mean no one has to manually clean up dangling GKE clusters.

The Circle CI error usually looks something like:
```
Error: Error deleting NodePool: googleapi: Error 400: Operation operation-1575485501339-e2faa04f is currently deleting a node pool for cluster circleci-test-259. Please wait and try again once it is done., failedPrecondition
```