### PR TITLE
revert pod security policy enable-by-default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "compute_node_type" {
 
 variable "enable_pod_security_policy" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "enable_network_policy" {


### PR DESCRIPTION
Installer still does not install the correct domino PSP by default (DOM-17498)