### PR TITLE
remove docker-registry service account binding

### DIFF
--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -76,11 +76,3 @@ resource "google_project_iam_member" "platform_monitoring" {
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.platform.email}"
 }
-
-resource "google_service_account_iam_binding" "platform_docker_registry" {
-  service_account_id = google_service_account.platform.name
-  role               = "roles/iam.workloadIdentityUser"
-  members = [
-    "serviceAccount:${var.project}.svc.id.goog[${var.platform_namespace}/docker-registry]",
-  ]
-}

--- a/variables.tf
+++ b/variables.tf
@@ -181,8 +181,3 @@ variable "platform_node_type" {
   type    = string
   default = "n1-standard-8"
 }
-
-variable "platform_namespace" {
-  type    = string
-  default = "domino-platform"
-}


### PR DESCRIPTION
In the past we'd discussed having this binding implicit based on the
namespace, but the current implementation in the installer requires the
SA reference:
https://github.com/cerebrotech/platform-apps/blob/ea635b2eb8ff485a79850c6df69f04e8c1493314/src/fleetcommand_agent/installer/config/types.py#L65

Might as well choose one way?