### PR TITLE
PLAT-2229: Adjust default node types, optional accelerator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       CLOUDSDK_CORE_PROJECT: domino-eng-platform-dev
       CLOUDSDK_COMPUTE_ZONE: us-west1-a
       GOOGLE_APPLICATION_CREDENTIALS: /root/.config/gcloud/legacy_credentials/terraform-gke-test@domino-eng-platform-dev.iam.gserviceaccount.com/adc.json
-      TERRAFORM_VERSION: 0.12.28
+      TERRAFORM_VERSION: 0.12.31
 
     steps:
       - checkout

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -6,8 +6,6 @@ locals {
 data "google_client_config" "current" {}
 
 provider "kubernetes" {
-  load_config_file = false
-
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.current.access_token
   cluster_ca_certificate = base64decode(local.cluster_ca_certificate)

--- a/main.tf
+++ b/main.tf
@@ -24,13 +24,6 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.20, != 3.29.0"
-  project = var.project
-  region  = local.region
-}
-
-provider "google-beta" {
-  version = "~> 3.20, != 3.29.0"
   project = var.project
   region  = local.region
 }
@@ -123,8 +116,6 @@ resource "google_filestore_instance" "nfs" {
 }
 
 resource "google_container_cluster" "domino_cluster" {
-  provider = google-beta
-
   name        = local.cluster
   location    = var.location
   description = var.description
@@ -318,9 +309,12 @@ resource "google_container_node_pool" "gpu" {
     preemptible  = var.gpu_nodes_preemptible
     machine_type = var.gpu_node_type
 
-    guest_accelerator {
-      type  = var.gpu_nodes_accelerator
-      count = 1
+    dynamic "guest_accelerator" {
+      for_each = [var.gpu_nodes_accelerator]
+      content {
+        type  = guest_accelerator.value
+        count = 1
+      }
     }
 
     tags = [

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "compute_nodes_ssd_gb" {
 
 variable "compute_node_type" {
   type    = string
-  default = "n1-highmem-8"
+  default = "n2-highmem-8"
 }
 
 variable "enable_pod_security_policy" {
@@ -192,7 +192,7 @@ variable "platform_nodes_ssd_gb" {
 
 variable "platform_node_type" {
   type    = string
-  default = "n1-standard-8"
+  default = "n2-standard-8"
 }
 
 variable "platform_namespace" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,10 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google      = ">=3.10.0"
-    google-beta = ">=3.10.0"
-    http        = ">=1.1.1"
-    kubernetes  = "~> 1.10.0"
-    local       = ">=1.4.0"
-    random      = ">=2.2"
+    google     = ">=3.68"
+    http       = ">=2.1"
+    kubernetes = "~> 2.2"
+    local      = ">=2.1"
+    random     = ">=3.1"
   }
 }


### PR DESCRIPTION
bump provider versions

platform and core node types are now n2.
the accelerator is now optional to allow for a2 which has no
accelerator.