### PR TITLE
remove default reliance on icanhazip.com

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,6 @@ terraform {
   }
 }
 
-data "http" "myip" {
-  url = "http://ipv4.icanhazip.com"
-}
-
 locals {
   cluster                 = var.cluster == null ? terraform.workspace : var.cluster
   enable_private_endpoint = length(var.master_authorized_networks_config) == 0
@@ -20,7 +16,7 @@ locals {
   region = length(split("-", var.location)) == 2 ? var.location : substr(var.location, 0, length(var.location) - 2)
   zone   = length(split("-", var.location)) == 3 ? var.location : format("%s-a", var.location)
 
-  authorized_networks = var.allow_local_ip_access ? concat(var.master_authorized_networks_config, [{ "display_name" : "myip", "cidr_block" : "${chomp(data.http.myip.body)}/32" }]) : var.master_authorized_networks_config
+  authorized_networks = var.master_authorized_networks_config
 }
 
 provider "google" {

--- a/variables.tf
+++ b/variables.tf
@@ -141,33 +141,11 @@ variable "master_authorized_networks_config" {
   }))
   default = [
     {
-      cidr_block   = "12.245.82.18/32"
-      display_name = "domino-hq"
-    },
-    {
-      cidr_block   = "52.206.158.130/32"
-      display_name = "aviatrix-east"
-    },
-    {
-      cidr_block   = "52.25.178.121/32"
-      display_name = "aviatrix-west"
-    },
-    {
-      cidr_block   = "52.56.39.158/32"
-      display_name = "aviatrix-eu"
-    },
-    {
-      cidr_block   = "13.126.91.85/32"
-      display_name = "aviatrix-ap"
+      cidr_block   = "0.0.0.0/0"
+      display_name = "global-access"
     }
   ]
   description = "Configuration options for master authorized networks. Default is for debugging only, and should be removed for production."
-}
-
-variable "allow_local_ip_access" {
-  type        = bool
-  default     = false
-  description = "Adds firewall rule to allow local access to Kubernetes cluster. This is required when executing terraform outside the master authorized networks."
 }
 
 variable "platform_nodes_max" {


### PR DESCRIPTION
http://ipv4.icanhazip.com has disappeared and realistically it's not great to rely on it by default anyhow.

Question is whether the 0.0.0.0/0 authorization is better than the current VPN IPs as a default.