### PR TITLE
pin node pool image types to COS and release channel to STABLE

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-* @Secretions @saahildhulla @steved
+* @dominodatalab/platform

--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,7 @@ resource "google_container_node_pool" "platform" {
   }
 
   node_config {
+    image_type   = var.platform_node_image_type
     preemptible  = var.platform_nodes_preemptible
     machine_type = var.platform_node_type
 
@@ -235,12 +236,16 @@ resource "google_container_node_pool" "platform" {
     delete = "20m"
   }
 
+  lifecycle {
+    ignore_changes = [autoscaling]
+  }
 }
 
 resource "google_container_node_pool" "compute" {
   name     = "compute"
   location = google_container_cluster.domino_cluster.location
   cluster  = google_container_cluster.domino_cluster.name
+
 
   initial_node_count = max(1, var.compute_nodes_min)
   autoscaling {
@@ -249,6 +254,7 @@ resource "google_container_node_pool" "compute" {
   }
 
   node_config {
+    image_type   = var.compute_node_image_type
     preemptible  = var.compute_nodes_preemptible
     machine_type = var.compute_node_type
 
@@ -275,6 +281,9 @@ resource "google_container_node_pool" "compute" {
     delete = "20m"
   }
 
+  lifecycle {
+    ignore_changes = [autoscaling]
+  }
 }
 
 resource "google_kms_key_ring" "key_ring" {
@@ -296,12 +305,14 @@ resource "google_container_node_pool" "gpu" {
 
   initial_node_count = max(0, var.gpu_nodes_min)
 
+
   autoscaling {
     max_node_count = var.gpu_nodes_max
     min_node_count = var.gpu_nodes_min
   }
 
   node_config {
+    image_type   = var.gpu_node_image_type
     preemptible  = var.gpu_nodes_preemptible
     machine_type = var.gpu_node_type
 
@@ -334,6 +345,9 @@ resource "google_container_node_pool" "gpu" {
     delete = "20m"
   }
 
+  lifecycle {
+    ignore_changes = [autoscaling]
+  }
 }
 
 # https://cloud.google.com/iap/docs/using-tcp-forwarding

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,7 @@ variable "enable_vertical_pod_autoscaling" {
 
 variable "gke_release_channel" {
   type        = string
-  default     = "REGULAR"
+  default     = "STABLE"
   description = "GKE K8s release channel for master"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,11 @@ variable "compute_nodes_ssd_gb" {
   default = 400
 }
 
+variable "compute_node_image_type" {
+  type    = string
+  default = "COS"
+}
+
 variable "compute_node_type" {
   type    = string
   default = "n2-highmem-8"
@@ -116,6 +121,11 @@ variable "gpu_nodes_min" {
 variable "gpu_nodes_preemptible" {
   type    = bool
   default = false
+}
+
+variable "gpu_node_image_type" {
+  type    = string
+  default = "COS"
 }
 
 variable "gpu_node_type" {
@@ -166,6 +176,11 @@ variable "platform_nodes_preemptible" {
 variable "platform_nodes_ssd_gb" {
   type    = number
   default = 100
+}
+
+variable "platform_node_image_type" {
+  type    = string
+  default = "COS"
 }
 
 variable "platform_node_type" {


### PR DESCRIPTION
GKE 1.19 swapped the default runtime / image type to COS_CONTAINERD which we currently do not support.

The REGULAR -> STABLE change isn't mandatory, but may give us more leeway in general.

The autoscaling changes seem helpful, since they can be modified during runtime and would be reset during a re-provision, but aren't required.