### PR TITLE
Resolve google_filestore_instance and google_kms_key_ring errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ resource "google_filestore_instance" "nfs" {
 
   name = local.uuid
   tier = "STANDARD"
-  zone = local.zone
+  zone = var.location
 
   file_shares {
     capacity_gb = var.filestore_capacity_gb
@@ -194,7 +194,7 @@ resource "google_kms_key_ring" "key_ring" {
 
 resource "google_kms_crypto_key" "crypto_key" {
   name            = local.uuid
-  key_ring        = google_kms_key_ring.key_ring.self_link
+  key_ring        = google_kms_key_ring.key_ring.id
   rotation_period = "86400s"
   purpose         = "ENCRYPT_DECRYPT"
 }


### PR DESCRIPTION
Updated [google_filestore_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) and [google_kms_key_ring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_key_ring#attributes-reference) reference (from [google_kms_crypto_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key#argument-reference)) per documentation regarding warning and error in apply

Resolves the following errors (from a v50+ deployer terraform plan of the subsequent tf):
```bash
╷
│ Warning: Argument is deprecated
│
│   with module.gke_cluster.google_filestore_instance.nfs,
│   on .terraform/modules/gke_cluster/main.tf line 95, in resource "google_filestore_instance" "nfs":
│   95:   zone = local.zone
│
│ Deprecated in favor of location.
╵
╷
│ Error: Unsupported attribute
│
│   on .terraform/modules/gke_cluster/main.tf line 197, in resource "google_kms_crypto_key" "crypto_key":
│  197:   key_ring        = google_kms_key_ring.key_ring.self_link
│
│ This object has no argument, nested block, or exported attribute named
│ "self_link".
╵
```

(planned main.tf, slightly truncated)
```hcl
module "gke_cluster" {
  source                     = "github.com/dominodatalab/terraform-gcp-gke?ref=v1.10.3"
  kubeconfig_output_path     = "/resources/deployer/deploys/dc-t7008579-2/kubeconfig"
  enable_pod_security_policy = true
  cluster_name               = "dc-t7008579-2"
  master_authorized_networks_config = [
    {
      cidr_block   = "0.0.0.0/0"
      display_name = "internet-ingress-access"
    }
  ]

  namespaces = {
    platform = "dc-t7008579-2-platform"
    compute  = "dc-t7008579-2-compute"
  }

  node_pool_overrides = {
    platform = {
      initial_count = 2
    }
    compute = {
      initial_count = 1
    }
  }

  master_firewall_ports = [ "443", ... ]

  location = "us-west1-b"

  google_dns_managed_zone = {
    name     = "eng-platform-dev"
    ...
  }
}
```