### PR TITLE
PLAT-4249: Make the DNS bits optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "google_project" "domino" {
 resource "random_uuid" "id" {}
 
 resource "google_compute_global_address" "static_ip" {
-  count = var.static_ip_disabled ? 0 : 1
+  count = var.static_ip_enabled ? 1 : 0
   name        = local.uuid
   description = "External static IPv4 address for var.description"
 }

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "google_compute_global_address" "static_ip" {
 }
 
 resource "google_dns_record_set" "a" {
+  count        = var.google_dns_managed_zone.enabled ? 0 : 1
   name         = "${var.cluster_name}.${var.google_dns_managed_zone.dns_name}"
   managed_zone = var.google_dns_managed_zone.name
   type         = "A"
@@ -40,6 +41,7 @@ resource "google_dns_record_set" "a" {
 }
 
 resource "google_dns_record_set" "caa" {
+  count        = var.google_dns_managed_zone.enabled ? 0 : 1
   name         = "${var.cluster_name}.${var.google_dns_managed_zone.dns_name}"
   managed_zone = var.google_dns_managed_zone.name
   type         = "CAA"

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "google_project" "domino" {
 resource "random_uuid" "id" {}
 
 resource "google_compute_global_address" "static_ip" {
-  count = var.static_ip_enabled ? 1 : 0
+  count       = var.static_ip_enabled ? 1 : 0
   name        = local.uuid
   description = "External static IPv4 address for var.description"
 }

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "google_compute_global_address" "static_ip" {
 }
 
 resource "google_dns_record_set" "a" {
-  count        = var.google_dns_managed_zone.enabled ? 0 : 1
+  count        = var.google_dns_managed_zone.enabled ? 1 : 0
   name         = "${var.cluster_name}.${var.google_dns_managed_zone.dns_name}"
   managed_zone = var.google_dns_managed_zone.name
   type         = "A"
@@ -41,7 +41,7 @@ resource "google_dns_record_set" "a" {
 }
 
 resource "google_dns_record_set" "caa" {
-  count        = var.google_dns_managed_zone.enabled ? 0 : 1
+  count        = var.google_dns_managed_zone.enabled ? 1 : 0
   name         = "${var.cluster_name}.${var.google_dns_managed_zone.dns_name}"
   managed_zone = var.google_dns_managed_zone.name
   type         = "CAA"

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ data "google_project" "domino" {
 resource "random_uuid" "id" {}
 
 resource "google_compute_global_address" "static_ip" {
+  count = var.static_ip_disabled ? 0 : 1
   name        = local.uuid
   description = "External static IPv4 address for var.description"
 }
@@ -37,7 +38,7 @@ resource "google_dns_record_set" "a" {
   type         = "A"
   ttl          = 300
 
-  rrdatas = [google_compute_global_address.static_ip.address]
+  rrdatas = [google_compute_global_address.static_ip[0].address]
 }
 
 resource "google_dns_record_set" "caa" {

--- a/output.tf
+++ b/output.tf
@@ -39,7 +39,7 @@ output "region" {
 }
 
 output "static_ip" {
-  value       = google_compute_global_address.static_ip.address
+  value       = !var.static_ip_disabled ? google_compute_global_address.static_ip[0].address : ""
   description = "The external (public) static IPv4 for the Domino UI"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -39,7 +39,7 @@ output "region" {
 }
 
 output "static_ip" {
-  value       = !var.static_ip_disabled ? google_compute_global_address.static_ip[0].address : ""
+  value       = var.static_ip_enabled ? google_compute_global_address.static_ip[0].address : ""
   description = "The external (public) static IPv4 for the Domino UI"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -17,7 +17,7 @@ output "cluster" {
 }
 
 output "dns" {
-  value       = google_dns_record_set.a.name
+  value       = var.google_dns_managed_zone.enabled ? google_dns_record_set.a[0].name : ""
   description = "The external (public) DNS name for the Domino UI"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "filestore_disabled" {
   description = "Do not provision a Filestore instance (mostly to avoid GCP Filestore API issues)"
 }
 
+variable "static_ip_disabled" {
+  type        = bool
+  default     = true
+  description = "Do not provision a static ip address"
+}
+
 variable "google_dns_managed_zone" {
   type = object({
     enabled  = bool

--- a/variables.tf
+++ b/variables.tf
@@ -37,10 +37,10 @@ variable "filestore_disabled" {
   description = "Do not provision a Filestore instance (mostly to avoid GCP Filestore API issues)"
 }
 
-variable "static_ip_disabled" {
+variable "static_ip_enabled" {
   type        = bool
-  default     = true
-  description = "Do not provision a static ip address"
+  default     = false
+  description = "Provision a static ip for use with managed zones/ingress"
 }
 
 variable "google_dns_managed_zone" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,12 +39,14 @@ variable "filestore_disabled" {
 
 variable "google_dns_managed_zone" {
   type = object({
+    enabled  = bool
     name     = string
     dns_name = string
   })
   default = {
-    name     = "eng-platform-dev"
-    dns_name = "eng-platform-dev.domino.tech."
+    enabled  = false
+    name     = ""
+    dns_name = ""
   }
   description = "Cloud DNS zone"
 }


### PR DESCRIPTION
In the interest of making this more suitable for external consumption, make the DNS section option and non-default.