### PR TITLE
PLAT-6345: Allow upgrades to 2.2.0 to work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         args:
           - '--args=--compact'
           - '--args=--quiet'
-          - '--args=--skip-check CKV_GCP_24,CKV_GCP_49,CKV_GCP_41,CKV_GCP_68,CKV_GCP_22,CKV_GCP_82,CKV_GCP_69,CKV_GCP_66,CKV_GCP_65,CKV_GCP_71,CKV_GCP_13,CKV_GCP_19,CKV_GCP_67,CKV_GCP_61,CKV_GCP_29,CKV_GCP_62,CKV_GCP_76,CKV_GCP_26,CKV_GCP_84,CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_GHA_1'
+          - '--args=--skip-check CKV_GCP_24,CKV_GCP_49,CKV_GCP_41,CKV_GCP_68,CKV_GCP_22,CKV_GCP_82,CKV_GCP_69,CKV_GCP_66,CKV_GCP_65,CKV_GCP_71,CKV_GCP_13,CKV_GCP_19,CKV_GCP_67,CKV_GCP_61,CKV_GCP_29,CKV_GCP_62,CKV_GCP_76,CKV_GCP_26,CKV_GCP_84,CKV_GCP_114,CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_GHA_1'
       - id: terraform_tfsec
         args:
           - '--args=--exclude google-gke-enforce-pod-security-policy,google-storage-bucket-encryption-customer-key,google-compute-enable-vpc-flow-logs,google-compute-no-public-ingress,google-gke-metadata-endpoints-disabled,google-gke-no-public-control-plane,google-gke-node-metadata-security,google-gke-use-service-account,google-storage-enable-ubla,google-iam-no-project-level-service-account-impersonation,google-gke-use-cluster-labels'

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0, < 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.0, < 5.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | 0.9.1 |
 
 ## Providers

--- a/gcr.tf
+++ b/gcr.tf
@@ -1,3 +1,8 @@
+provider "google-beta" {
+  project = var.project
+  region  = local.region
+}
+
 resource "google_artifact_registry_repository" "domino" {
   location      = local.region
   repository_id = "${var.deploy_id}-domino"

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/time"
       version = "0.9.1"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.0, < 5.0"
+    }
   }
 }


### PR DESCRIPTION
Resources are no longer tied to google-beta, however the tfstate still has references to the google-beta provider. Add back the google-beta provider so that they may be resolved but not used.

Revisit the public access protection on buckets. It currently inherits the organization policy which may allow public access.