### PR TITLE
PLAT-6345: Allow upgrades to 2.2.0 to work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         args:
           - '--args=--compact'
           - '--args=--quiet'
-          - '--args=--skip-check CKV_GCP_24,CKV_GCP_49,CKV_GCP_41,CKV_GCP_68,CKV_GCP_22,CKV_GCP_82,CKV_GCP_69,CKV_GCP_66,CKV_GCP_65,CKV_GCP_71,CKV_GCP_13,CKV_GCP_19,CKV_GCP_67,CKV_GCP_61,CKV_GCP_29,CKV_GCP_62,CKV_GCP_76,CKV_GCP_26,CKV_GCP_84,CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6'
+          - '--args=--skip-check CKV_GCP_24,CKV_GCP_49,CKV_GCP_41,CKV_GCP_68,CKV_GCP_22,CKV_GCP_82,CKV_GCP_69,CKV_GCP_66,CKV_GCP_65,CKV_GCP_71,CKV_GCP_13,CKV_GCP_19,CKV_GCP_67,CKV_GCP_61,CKV_GCP_29,CKV_GCP_62,CKV_GCP_76,CKV_GCP_26,CKV_GCP_84,CKV_GCP_114,CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_GHA_1'
       - id: terraform_tfsec
         args:
           - '--args=--exclude google-gke-enforce-pod-security-policy,google-storage-bucket-encryption-customer-key,google-compute-enable-vpc-flow-logs,google-compute-no-public-ingress,google-gke-metadata-endpoints-disabled,google-gke-no-public-control-plane,google-gke-node-metadata-security,google-gke-use-service-account,google-storage-enable-ubla,google-iam-no-project-level-service-account-impersonation,google-gke-use-cluster-labels'

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.38.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 4.38.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.47.0 |
 
 ## Modules
 
@@ -91,9 +90,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_artifact_registry_repository.domino](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository) | resource |
-| [google-beta_google_artifact_registry_repository_iam_member.gcr](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository_iam_member) | resource |
-| [google-beta_google_container_cluster.domino_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
+| [google_artifact_registry_repository.domino](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
+| [google_artifact_registry_repository_iam_member.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_compute_firewall.iap_tcp_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.master_webhooks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_global_address.static_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
@@ -101,6 +99,7 @@ No modules.
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
 | [google_compute_subnetwork.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
+| [google_container_cluster.domino_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) | resource |
 | [google_container_node_pool.node_pools](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
 | [google_dns_record_set.a](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_dns_record_set.caa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
@@ -124,7 +123,6 @@ No modules.
 | <a name="input_deploy_id"></a> [deploy\_id](#input\_deploy\_id) | Domino Deployment ID. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | GKE cluster description | `string` | `"The Domino K8s Cluster"` | no |
 | <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | Enable network policy switch | `bool` | `true` | no |
-| <a name="input_enable_pod_security_policy"></a> [enable\_pod\_security\_policy](#input\_enable\_pod\_security\_policy) | Enable pod security policy switch | `bool` | `true` | no |
 | <a name="input_enable_vertical_pod_autoscaling"></a> [enable\_vertical\_pod\_autoscaling](#input\_enable\_vertical\_pod\_autoscaling) | Enable GKE vertical scaling | `bool` | `true` | no |
 | <a name="input_filestore_capacity_gb"></a> [filestore\_capacity\_gb](#input\_filestore\_capacity\_gb) | Filestore Instance size (GB) for the cluster nfs shared storage | `number` | `1024` | no |
 | <a name="input_filestore_disabled"></a> [filestore\_disabled](#input\_filestore\_disabled) | Do not provision a Filestore instance (mostly to avoid GCP Filestore API issues) | `bool` | `false` | no |

--- a/gcr.tf
+++ b/gcr.tf
@@ -1,3 +1,8 @@
+provider "google-beta" {
+  project = var.project
+  region  = local.region
+}
+
 resource "google_artifact_registry_repository" "domino" {
   location      = local.region
   repository_id = "${var.deploy_id}-domino"

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.1"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.0, < 5.0"
+    }
   }
 }


### PR DESCRIPTION
Resources are no longer tied to google-beta, however the tfstate still has references to the google-beta provider. Add back the google-beta provider so that they may be resolved but not used.

Creating a special 2.2.0.1 tag so we only pick up this one change.