### PR TITLE
remove additional local SSDs on node pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -280,8 +280,7 @@ resource "google_container_node_pool" "node_pools" {
       }
     }
 
-    disk_size_gb    = each.value.disk_size_gb
-    local_ssd_count = 1
+    disk_size_gb = each.value.disk_size_gb
 
     metadata = {
       "disable-legacy-endpoints" = true


### PR DESCRIPTION
`local_ssds` are [ephemeral storage](https://cloud.google.com/kubernetes-engine/docs/concepts/local-ssd) that must be explicitly mounted or use opt-in features like emptyDir SSDs. Domino only requires a larger boot disk to hold container images.

Some instance types (like n2-standard-16) require even numbered SSDs (2, 4, etc.) which this hardcoded value precludes.