### PR TITLE
update workload ID binding for hephaestus, rm target_tags for master firewall rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -328,5 +328,5 @@ resource "google_compute_firewall" "master_webhooks" {
   }
 
   source_ranges = [google_container_cluster.domino_cluster.private_cluster_config[0].master_ipv4_cidr_block]
-  target_tags   = ["domino-platform-node"]
+  target_tags   = ["domino-platform-node", "domino-compute-node"]
 }

--- a/main.tf
+++ b/main.tf
@@ -328,5 +328,4 @@ resource "google_compute_firewall" "master_webhooks" {
   }
 
   source_ranges = [google_container_cluster.domino_cluster.private_cluster_config[0].master_ipv4_cidr_block]
-  target_tags   = ["domino-platform-node", "domino-compute-node"]
 }

--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -41,6 +41,6 @@ resource "google_service_account_iam_binding" "gcr" {
   role               = "roles/iam.workloadIdentityUser"
   members = [
     "serviceAccount:${var.project}.svc.id.goog[${var.namespaces.compute}/forge]",
-    "serviceAccount:${var.project}.svc.id.goog[${var.namespaces.platform}/hephaestus]"
+    "serviceAccount:${var.project}.svc.id.goog[${var.namespaces.compute}/hephaestus]"
   ]
 }


### PR DESCRIPTION
this was noticed as hephaestus was moved to `domino-compute` in 5.7.0, causing webhook calls to fail - it would be necessary to add the `domino-compute-node` target_tag to the existing firewall rule to support webhooks were we to keep that paradigm, but limiting the rule just to `domino-platform-node` excludes istio support, so removing the tags ensures services on any node will have the firewall rule applied.

this also updates the workload ID binding namespace to compute for hephaestus rather than platform