### PR TITLE
bump pre-commit-terraform to v1.81.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: no-commit-to-branch
       - id: check-case-conflict
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.81.0
     hooks:
       - id: terraform_docs
         args:

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "google" {
     enabled = true
-    version = "0.20.0"
+    version = "0.23.1"
     source  = "github.com/terraform-linters/tflint-ruleset-google"
 }


### PR DESCRIPTION
pre-commit hook is failing in `master` due to an incompatible dependency error:

```
Terraform validate with tflint...........................................Failed
- hook id: terraform_tflint
- exit code: 1

Command 'tflint --init' successfully done:
Installing `google` plugin...
Installed `google` (source: github.com/terraform-linters/tflint-ruleset-google, version: 0.20.0)

TFLint in ./:
Plugin "google" SDK version is incompatible. Compatible versions: >= 0.14.0
TFLint in tests/:
Plugin "google" SDK version is incompatible. Compatible versions: >= 0.14.0
```

the `terraform_tflint` hook has the git working dir path workaround in place, though, which tells tflint to source from the module versions set in the root `.tflint.hcl` file, so the issue isn't with the configuration there, but since we pull the latest `tflint` binary to install in the circleci job, i.e.:

```
curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
```

the issue appears to be an upstream incompatibility with the tflint binary itself and the google ruleset plugin. since we're already behind, this updates the version for both the pre-commit-terraform and github.com/terraform-linters/tflint-ruleset-google deps (though updating tflint-ruleset-google was all that was needed to resolve the error)