### PR TITLE
[PLAT-6884] GCP from fleetcommand fails

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,10 @@ locals {
 provider "google" {
   project = var.project
   region  = local.region
+  batching {
+    enable_batching = true
+    send_after      = "15s"
+  }
 }
 
 data "google_project" "domino" {


### PR DESCRIPTION
This is enables batching for resources that support it and prevents node pool creation from failing with
rateLimitExceeded