### PR TITLE
Push more of the arg generation into ddlcloud

### DIFF
--- a/ddlcloud_generator_gke/util.py
+++ b/ddlcloud_generator_gke/util.py
@@ -2,27 +2,10 @@
 
 import argparse
 import sys
-from os import path
-from os.path import dirname, join, normpath
-from subprocess import run
-from tempfile import TemporaryDirectory
 
 import yaml
-from domino_tf_base_schemas import TFBackendConfig, TFLocalBackend
 
 from ddlcloud_generator_gke import GKEGenerator
-
-module_root = normpath(join(dirname(path.realpath(__file__)), ".."))
-
-
-def validate(module):
-    with TemporaryDirectory() as tmpdir:
-        module.backend = TFBackendConfig(type="local", config=TFLocalBackend(path=path.join(tmpdir, "the.tfstate")))
-        module.module.gke_cluster.source = module_root
-        with open(path.join(tmpdir, "main.tf.json"), "w") as f:
-            f.write(module.render_to_json())
-        run(["terraform", "init"], cwd=tmpdir, check=True)
-        run(["terraform", "validate"], cwd=tmpdir, check=True)
 
 
 def parse_args(test_args: list | None = None):

--- a/ddlcloud_generator_gke/v1_0.py
+++ b/ddlcloud_generator_gke/v1_0.py
@@ -173,17 +173,11 @@ class GKEGenerator:
         return cls.load_tfset(existing_config)
 
     @classmethod
-    def subparser(cls, subparser, parents):
-        gke_subparser = subparser.add_parser("gke", help="GKE Terraform Generator", parents=parents)
-        gke_subparser.add_argument("--location", help="GCP Location (ie region/zone)", default="us-west1-b")
-        gke_subparser.add_argument("--kubernetes-version", help="Kubernetes Version", default="1.21")
-        gke_subparser.add_argument("--module-version", help="Version of terraform-gcp-gke module", default="v3.1.3")
-        gke_subparser.add_argument(
-            "--kubeconfig-path", help="Override path for generated kubeconfig", default="kubeconfig"
-        )
-        gke_subparser.add_argument("--dev", help="Development defaults", action="store_true")
-        gke_subparser.set_defaults(generator=cls.generate_gke_module)
-        return gke_subparser
+    def add_specific_args(cls, parser):
+        parser.add_argument("--location", help="GCP Location (ie region/zone)", default="us-west1-b")
+        parser.add_argument("--kubernetes-version", help="Kubernetes Version", default="1.21")
+        parser.add_argument("--dev", help="Development defaults", action="store_true")
+        parser.set_defaults(generator=cls.generate_gke_module)
 
     @classmethod
     def generate_gke_module(cls, args, existing_config: dict | None) -> TFSet:

--- a/pytests/generate.py
+++ b/pytests/generate.py
@@ -28,11 +28,16 @@ def validate(module):
 def parse_args(test_args: list | None = None):
     parser = argparse.ArgumentParser(prog="gke_test")
     subparser = parser.add_subparsers(title="Commands", metavar="{command}")
-    common_args = argparse.ArgumentParser(add_help=False)
-    common_args.add_argument("--upgrade", help="Upgrade from existing file", action="store_true")
-    common_args.add_argument("--deploy-id", help="Name for deployment", required=True)
-    common_args.add_argument("--file", help="Load existing file")
-    GKEGenerator.subparser(subparser, [common_args]).set_defaults(command=True)
+    _gen_args_parser = subparser.add_parser("gke", help="gke Terraform Generator")
+    _gen_args_parser.add_argument("--upgrade", help="Upgrade from existing file", action="store_true")
+    _gen_args_parser.add_argument("--deploy-id", help="Name for deployment", required=True)
+    _gen_args_parser.add_argument("--file", help="Load existing file")
+    _gen_args_parser.add_argument(
+        "--kubeconfig-path", help="Override path for generated kubeconfig", default="kubeconfig"
+    )
+    _gen_args_parser.add_argument("--module-version", help="Version for terraform module", default="v3.1.3")
+    GKEGenerator.add_specific_args(_gen_args_parser)
+    _gen_args_parser.set_defaults(command=True)
 
     args = parser.parse_args(test_args)
 

--- a/pytests/test_generator.py
+++ b/pytests/test_generator.py
@@ -1,7 +1,12 @@
 from copy import deepcopy
+from os import path
+from os.path import dirname, join, normpath
+from subprocess import run
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import yaml
+from domino_tf_base_schemas import TFBackendConfig, TFLocalBackend
 
 from ddlcloud_generator_gke import (
     GKEGenerator,
@@ -9,8 +14,19 @@ from ddlcloud_generator_gke import (
     GKENodePool,
     GKEStorage,
 )
+from ddlcloud_generator_gke.util import parse_args
 
-from .generate import parse_args, validate
+module_root = normpath(join(dirname(path.realpath(__file__)), ".."))
+
+
+def validate(module):
+    with TemporaryDirectory() as tmpdir:
+        module.backend = TFBackendConfig(type="local", config=TFLocalBackend(path=path.join(tmpdir, "the.tfstate")))
+        module.module.gke_cluster.source = module_root
+        with open(path.join(tmpdir, "main.tf.json"), "w") as f:
+            f.write(module.render_to_json())
+        run(["terraform", "init"], cwd=tmpdir, check=True)
+        run(["terraform", "validate"], cwd=tmpdir, check=True)
 
 
 class TestGenerator(TestCase):


### PR DESCRIPTION
* https://dominodatalab.atlassian.net/browse/PLAT-9137
* https://dominodatalab.atlassian.net/browse/PLAT-9138
* https://dominodatalab.atlassian.net/browse/PLAT-9143

The `--module-version` default has a chicken/egg issue when it lives here, so simplifying the args a bit such that we only take in an extant parser and treat both the `--kubeconfig-path` and `--module-version` args as part of the boilerplate that lives in ddlcloud.