### PR TITLE
DOM-74110 Add GCR credential refresher for Artifact Registry authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ No modules.
 |------|------|
 | [google_artifact_registry_repository.domino](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
 | [google_artifact_registry_repository_iam_member.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_artifact_registry_repository_iam_member.gcr_credential_refresher_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_artifact_registry_repository_iam_member.platform](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_compute_disk.nfs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_compute_firewall.iap_tcp_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
@@ -143,8 +144,10 @@ No modules.
 | [google_project_iam_member.platform_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.accounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.gcr_credential_refresher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_binding.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_binding.platform_gcs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_member.gcr_credential_refresher_workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_binding.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [terraform_data.kubeconfig](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
@@ -177,6 +180,7 @@ No modules.
 | <a name="output_cluster"></a> [cluster](#output\_cluster) | GKE cluster information |
 | <a name="output_dns"></a> [dns](#output\_dns) | The external (public) DNS name for the Domino UI |
 | <a name="output_domino_artifact_repository"></a> [domino\_artifact\_repository](#output\_domino\_artifact\_repository) | Domino Google artifact repository |
+| <a name="output_gcr_credential_refresher"></a> [gcr\_credential\_refresher](#output\_gcr\_credential\_refresher) | Configuration for the GCR credential refresher Helm chart values |
 | <a name="output_google_filestore_instance"></a> [google\_filestore\_instance](#output\_google\_filestore\_instance) | Domino Google Cloud Filestore instance, name and ip\_address |
 | <a name="output_nfs_instance"></a> [nfs\_instance](#output\_nfs\_instance) | Domino Google Cloud Filestore instance, name and ip\_address |
 | <a name="output_nfs_instance_ip"></a> [nfs\_instance\_ip](#output\_nfs\_instance\_ip) | NFS instance IP |

--- a/gcr-credential-refresher.tf
+++ b/gcr-credential-refresher.tf
@@ -1,0 +1,32 @@
+#===============================================================================
+# GCR Credential Refresher for Gen AI Model Operations
+#
+# Provisions a dedicated GCP service account with Artifact Registry read access
+# and GKE Workload Identity binding. The GcrCredentialRefresher CronJob
+# (deployed via Helm) uses this identity to obtain short-lived access tokens
+# and populate the domino-registry Kubernetes secret.
+#
+# This follows the same pattern as EcrCredentialRefresher (EKS) and
+# AcrCredentialRefresher (AKS).
+#===============================================================================
+
+resource "google_service_account" "gcr_credential_refresher" {
+  account_id   = "${var.deploy_id}-gcr-cred"
+  display_name = "${var.deploy_id} GCR Credential Refresher"
+  description  = "Used by the GCR credential refresher CronJob to obtain access tokens for Artifact Registry"
+  project      = var.project
+}
+
+resource "google_artifact_registry_repository_iam_member" "gcr_credential_refresher_reader" {
+  repository = google_artifact_registry_repository.domino.name
+  location   = google_artifact_registry_repository.domino.location
+
+  role   = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.gcr_credential_refresher.email}"
+}
+
+resource "google_service_account_iam_member" "gcr_credential_refresher_workload_identity" {
+  service_account_id = google_service_account.gcr_credential_refresher.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project}.svc.id.goog[${var.namespaces.platform}/nucleus-gcr-credential-refresher]"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,6 +59,14 @@ output "domino_artifact_repository" {
   description = "Domino Google artifact repository"
 }
 
+output "gcr_credential_refresher" {
+  value = {
+    service_account_email = google_service_account.gcr_credential_refresher.email
+    registry_server       = "${google_artifact_registry_repository.domino.location}-docker.pkg.dev"
+  }
+  description = "Configuration for the GCR credential refresher Helm chart values"
+}
+
 output "nfs_instance_ip" {
   value       = var.storage.nfs_instance.enabled ? google_compute_instance.nfs[0].network_interface[0].network_ip : ""
   description = "NFS instance IP"


### PR DESCRIPTION
### Link to JIRA

[DOM-74110](https://dominodatalab.atlassian.net/browse/DOM-74110)

### What issue does this pull request solve?

Gen AI model registration is blocked in GCP (GKE) deployments because server-side OCI manifest checks and executor-side crane downloads lack Artifact Registry credentials. The existing GKE node service account only works for kubelet image pulls, not for OCI registry API calls made by Nucleus or crane in executor pods.

### What is the solution?

Provisions a dedicated GCP service account with Artifact Registry read access and GKE Workload Identity binding for the GCR credential refresher CronJob:

- **`google_service_account.gcr_credential_refresher`** -- Dedicated SA (`${deploy_id}-gcr-cred`) for the refresher
- **`google_artifact_registry_repository_iam_member.gcr_credential_refresher_reader`** -- `roles/artifactregistry.reader` scoped to the domino repository (least privilege)
- **`google_service_account_iam_member.gcr_credential_refresher_workload_identity`** -- Binds the K8s ServiceAccount (`nucleus-gcr-credential-refresher` in the platform namespace) to the GCP SA via Workload Identity
- **`gcr_credential_refresher` output** -- Exposes `service_account_email` and `registry_server` for downstream Helm value wiring via platform-apps

This follows the same pattern as the existing ECR (EKS) and ACR (AKS) credential refresher infrastructure. The CronJob itself is deployed via the nucleus Helm chart (separate PR).

### References (optional)

- https://github.com/dominodatalab/terraform-gcp-gke/pull/129
- https://github.com/cerebrotech/operations-gcr-credential-refresher-docker/pull/2
- https://github.com/cerebrotech/charts/pull/2481
- https://github.com/cerebrotech/catalog/pull/5396
- https://github.com/cerebrotech/platform-apps/pull/10044