### PR TITLE
DOM-74110 Add GcrCredentialRefresherOutput to GKEOutputs

### DIFF
--- a/ddlcloud_generator_gke/v1_0.py
+++ b/ddlcloud_generator_gke/v1_0.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Self
+from typing import Self, Union
 
 from domino_tf_base_schemas import (
     BaseTFConfig,
@@ -13,6 +13,11 @@ from pydantic import model_validator
 
 class GKEGeneratorException(Exception):
     pass
+
+
+class GcrCredentialRefresherOutput(ValidatingBaseModel):
+    service_account_email: str
+    registry_server: str
 
 
 class GKEOutputs(BaseTFOutput):
@@ -30,6 +35,9 @@ class GKEOutputs(BaseTFOutput):
     )
     nfs_instance_ip: str = "${module.gke_cluster.nfs_instance.ip_address}"
     nfs_instance_path: str = "${module.gke_cluster.nfs_instance.nfs_path}"
+    gcr_credential_refresher: Union[str, GcrCredentialRefresherOutput] = (
+        "${module.gke_cluster.gcr_credential_refresher}"
+    )
 
 
 class GKENamespaces(ValidatingBaseModel):

--- a/pytests/fixtures/defaults.yaml
+++ b/pytests/fixtures/defaults.yaml
@@ -98,6 +98,7 @@ configs:
       google_project: ${module.gke_cluster.project}
       nfs_instance_ip: ${module.gke_cluster.nfs_instance.ip_address}
       nfs_instance_path: ${module.gke_cluster.nfs_instance.nfs_path}
+      gcr_credential_refresher: ${module.gke_cluster.gcr_credential_refresher}
     remote_module_refs: null
 module_id: gke
 version: '1.0'


### PR DESCRIPTION
### Link to JIRA

[DOM-74110](https://dominodatalab.atlassian.net/browse/DOM-74110)

### What issue does this pull request solve?

GKE deployments on `release-6.2.1` (FleetCommand/ddlcloud path) fail to register GenAI models because the `gcr_credential_refresher` Terraform output is never captured. The `GKEOutputs` class in `ddlcloud_generator_gke` lacks a field for it, so the generated Terraform config has no output block and the installer never receives the GCR credential refresher service account email.

### What is the solution?

Add `GcrCredentialRefresherOutput` model and `gcr_credential_refresher` field to `GKEOutputs`. The `Union[str, GcrCredentialRefresherOutput]` type serves dual purpose: during Terraform generation it holds the interpolation string for the output block, and during output parsing it deserializes into the structured model so the installer can read `service_account_email`.

### References (optional)

- https://github.com/dominodatalab/terraform-gcp-gke/pull/130
- https://github.com/cerebrotech/operations-ddlcloud-docker/pull/65
- https://github.com/cerebrotech/domino-config/pull/278
- https://github.com/cerebrotech/platform-python-catalog/pull/183
- https://github.com/cerebrotech/platform-apps/pull/10051
- https://github.com/cerebrotech/catalog/pull/5450

