### PR TITLE
DOM-79156 Add GCNV storage backend for Trident on GKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,18 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0, < 8.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.28.0, < 8.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 5.0, < 8.0 |
+| <a name="requirement_netapp-ontap"></a> [netapp-ontap](#requirement\_netapp-ontap) | 2.7.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0, < 8.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 7.28.0, < 8.0 |
+| <a name="provider_netapp-ontap"></a> [netapp-ontap](#provider\_netapp-ontap) | 2.7.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -125,9 +127,11 @@ No modules.
 | [google_compute_firewall.iap_tcp_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.master_webhooks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.nfs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_global_address.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_global_address.static_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_instance.nfs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
 | [google_compute_network.vpc_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_compute_network_peering_routes_config.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering_routes_config) | resource |
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
 | [google_compute_subnetwork.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
@@ -141,18 +145,30 @@ No modules.
 | [google_kms_crypto_key.crypto_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key) | resource |
 | [google_kms_crypto_key_iam_binding.binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_binding) | resource |
 | [google_kms_key_ring.key_ring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring) | resource |
+| [google_netapp_storage_pool.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/netapp_storage_pool) | resource |
+| [google_project_iam_custom_role.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.gcnv_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.platform_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.accounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.gcr_credential_refresher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_binding.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_binding.platform_gcs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_member.gcr_credential_refresher_workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_networking_connection.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 | [google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_binding.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
+| [netapp-ontap_nfs_export_policy_rule.gcnv_node_access](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.7.0/docs/resources/nfs_export_policy_rule) | resource |
+| [terraform_data.gcnv_ontap_ready](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.gcnv_volume_cleanup](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.kubeconfig](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [google_compute_zones.gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 | [google_project.domino](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_storage_project_service_account.gcs_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
+| [netapp-ontap_volumes.gcnv](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.7.0/docs/data-sources/volumes) | data source |
 
 ## Inputs
 
@@ -169,7 +185,7 @@ No modules.
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | Namespace that are used for generating the service account bindings | `object({ platform = string, compute = string })` | n/a | yes |
 | <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | GKE node pool params | <pre>object(<br/>    {<br/>      compute = object({<br/>        min_count       = optional(number, 0)<br/>        max_count       = optional(number, 10)<br/>        initial_count   = optional(number, 1)<br/>        max_pods        = optional(number, 30)<br/>        preemptible     = optional(bool, false)<br/>        disk_size_gb    = optional(number, 400)<br/>        image_type      = optional(string, "COS_CONTAINERD")<br/>        instance_type   = optional(string, "n2-highmem-8")<br/>        gpu_accelerator = optional(string, "")<br/>        labels = optional(map(string), {<br/>          "dominodatalab.com/node-pool" = "default"<br/>        })<br/>        taints         = optional(list(string), [])<br/>        node_locations = optional(list(string), [])<br/>      }),<br/>      platform = object({<br/>        min_count       = optional(number, 1)<br/>        max_count       = optional(number, 5)<br/>        initial_count   = optional(number, 1)<br/>        max_pods        = optional(number, 60)<br/>        preemptible     = optional(bool, false)<br/>        disk_size_gb    = optional(number, 100)<br/>        image_type      = optional(string, "COS_CONTAINERD")<br/>        instance_type   = optional(string, "n2-standard-8")<br/>        gpu_accelerator = optional(string, "")<br/>        labels = optional(map(string), {<br/>          "dominodatalab.com/node-pool" = "platform"<br/>        })<br/>        taints         = optional(list(string), [])<br/>        node_locations = optional(list(string), [])<br/>      }),<br/>      gpu = object({<br/>        min_count       = optional(number, 0)<br/>        max_count       = optional(number, 2)<br/>        initial_count   = optional(number, 0)<br/>        max_pods        = optional(number, 30)<br/>        preemptible     = optional(bool, false)<br/>        disk_size_gb    = optional(number, 400)<br/>        image_type      = optional(string, "COS_CONTAINERD")<br/>        instance_type   = optional(string, "n1-highmem-8")<br/>        gpu_accelerator = optional(string, "nvidia-tesla-p100")<br/>        labels = optional(map(string), {<br/>          "dominodatalab.com/node-pool" = "default-gpu"<br/>          "nvidia.com/gpu"              = "true"<br/>        })<br/>        taints = optional(list(string), [<br/>          "nvidia.com/gpu=true:NoExecute"<br/>        ])<br/>        node_locations = optional(list(string), [])<br/>      })<br/>  })</pre> | <pre>{<br/>  "compute": {},<br/>  "gpu": {},<br/>  "platform": {}<br/>}</pre> | no |
 | <a name="input_project"></a> [project](#input\_project) | GCP Project ID | `string` | `"domino-eng-platform-dev"` | no |
-| <a name="input_storage"></a> [storage](#input\_storage) | storage = {<br/>    filestore = {<br/>      enabled = Provision a Filestore instance (for production installs)<br/>      capacity\_gb = Filestore Instance size (GB) for the cluster NFS shared storage<br/>    }<br/>    nfs\_instance = {<br/>      enabled = Provision an instance as an NFS server (to avoid filestore churn during testing)<br/>      capacity\_gb = NFS instance disk size<br/>    }<br/>    gcs = {<br/>      force\_destroy\_on\_deletion = Toogle to allow recursive deletion of all objects in the bucket. if 'false' terraform will NOT be able to delete non-empty buckets.<br/>    } | <pre>object({<br/>    filestore = optional(object({<br/>      enabled     = optional(bool, true)<br/>      capacity_gb = optional(number, 1024)<br/>    }), {}),<br/>    nfs_instance = optional(object({<br/>      enabled     = optional(bool, false)<br/>      capacity_gb = optional(number, 100)<br/>    }), {}),<br/>    gcs = optional(object({<br/>      force_destroy_on_deletion = optional(bool, false)<br/>    }), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_storage"></a> [storage](#input\_storage) | storage = {<br/>    filestore = {<br/>      enabled = Provision a Filestore instance (for production installs)<br/>      capacity\_gb = Filestore Instance size (GB) for the cluster NFS shared storage<br/>    }<br/>    nfs\_instance = {<br/>      enabled = Provision an instance as an NFS server (to avoid filestore churn during testing)<br/>      capacity\_gb = NFS instance disk size<br/>    }<br/>    gcs = {<br/>      force\_destroy\_on\_deletion = Toogle to allow recursive deletion of all objects in the bucket. if 'false' terraform will NOT be able to delete non-empty buckets.<br/>    }<br/>    gcnv = {<br/>      enabled = Provision a Google Cloud NetApp Volumes storage pool in ONTAP-mode (Trident GCNV backend)<br/>      pool\_capacity\_gib = GCNV storage pool capacity (GiB)<br/>      trident\_namespace = Namespace containing the Trident controller service account<br/>      regional = If true, create a zone-redundant (regional) pool with two synchronous replicas across two zones; if false (default), a single-zone (zonal) pool.<br/>      primary\_zone = Active zone for a regional pool. Required when regional is true.<br/>      replica\_zone = Standby zone for a regional pool. Required when regional is true.<br/>    } | <pre>object({<br/>    filestore = optional(object({<br/>      enabled     = optional(bool, true)<br/>      capacity_gb = optional(number, 1024)<br/>    }), {}),<br/>    nfs_instance = optional(object({<br/>      enabled     = optional(bool, false)<br/>      capacity_gb = optional(number, 100)<br/>    }), {}),<br/>    gcs = optional(object({<br/>      force_destroy_on_deletion = optional(bool, false)<br/>    }), {}),<br/>    gcnv = optional(object({<br/>      enabled           = optional(bool, false)<br/>      pool_capacity_gib = optional(number, 1024)<br/>      trident_namespace = optional(string, "trident")<br/>      regional          = optional(bool, false)<br/>      primary_zone      = optional(string)<br/>      replica_zone      = optional(string)<br/>    }), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Deployment tags. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -180,6 +196,7 @@ No modules.
 | <a name="output_cluster"></a> [cluster](#output\_cluster) | GKE cluster information |
 | <a name="output_dns"></a> [dns](#output\_dns) | The external (public) DNS name for the Domino UI |
 | <a name="output_domino_artifact_repository"></a> [domino\_artifact\_repository](#output\_domino\_artifact\_repository) | Domino Google artifact repository |
+| <a name="output_gcnv"></a> [gcnv](#output\_gcnv) | GCNV ONTAP-mode pool and Trident service account. |
 | <a name="output_gcr_credential_refresher"></a> [gcr\_credential\_refresher](#output\_gcr\_credential\_refresher) | Configuration for the GCR credential refresher Helm chart values |
 | <a name="output_google_filestore_instance"></a> [google\_filestore\_instance](#output\_google\_filestore\_instance) | Domino Google Cloud Filestore instance, name and ip\_address |
 | <a name="output_nfs_instance"></a> [nfs\_instance](#output\_nfs\_instance) | Domino Google Cloud Filestore instance, name and ip\_address |

--- a/ddlcloud_generator_gke/v1_0.py
+++ b/ddlcloud_generator_gke/v1_0.py
@@ -38,6 +38,13 @@ class GKEOutputs(BaseTFOutput):
     gcr_credential_refresher: Union[str, GcrCredentialRefresherOutput] = (
         "${module.gke_cluster.gcr_credential_refresher}"
     )
+    gcnv_project_number: str = "${module.gke_cluster.gcnv.project_number}"
+    gcnv_location: str = "${module.gke_cluster.gcnv.location}"
+    gcnv_storage_pool_name: str = "${module.gke_cluster.gcnv.storage_pool_name}"
+    gcnv_service_account_email: str = "${module.gke_cluster.gcnv.service_account_email}"
+    gcnv_client_cidr: str = "${module.gke_cluster.gcnv.client_cidr}"
+    gcnv_root_volume_name: str = "${module.gke_cluster.gcnv.root_volume_name}"
+    gcnv_export_policy_name: str = "${module.gke_cluster.gcnv.export_policy_name}"
 
 
 class GKENamespaces(ValidatingBaseModel):
@@ -53,14 +60,32 @@ class GKEStorage(ValidatingBaseModel):
     class GCSSettings(ValidatingBaseModel):
         force_destroy_on_deletion: bool = False
 
+    class GCNVSettings(ValidatingBaseModel):
+        enabled: bool = False
+        pool_capacity_gib: int = 1024
+        trident_namespace: str = "trident"
+        regional: bool = False
+        primary_zone: str | None = None
+        replica_zone: str | None = None
+
     filestore: Store = Store(enabled=True, capacity=1024)
     nfs_instance: Store = Store(enabled=False, capacity=100)
     gcs: GCSSettings = GCSSettings()
+    gcnv: GCNVSettings = GCNVSettings()
 
     @model_validator(mode="after")
     def validate_stores(self) -> Self:
-        if self.filestore.enabled and self.nfs_instance.enabled:
-            raise ValueError("Cannot enable both filestore and nfs instance")
+        enabled = [
+            name
+            for name, is_enabled in (
+                ("filestore", self.filestore.enabled),
+                ("nfs_instance", self.nfs_instance.enabled),
+                ("gcnv", self.gcnv.enabled),
+            )
+            if is_enabled
+        ]
+        if len(enabled) > 1:
+            raise ValueError(f"Multiple shared stores enabled: {', '.join(enabled)}")
         return self
 
 

--- a/gcnv.tf
+++ b/gcnv.tf
@@ -1,0 +1,135 @@
+# Terraform owns the GCNV pool; Trident manages its ONTAP volumes.
+locals {
+  gcnv_regional     = var.storage.gcnv.regional
+  gcnv_zone_lookup  = var.storage.gcnv.enabled && !local.gcnv_regional && local.is_regional
+  gcnv_location     = local.gcnv_zone_lookup ? sort(data.google_compute_zones.gcnv[0].names)[0] : (local.gcnv_regional ? local.region : local.zone)
+  gcnv_primary_zone = local.gcnv_regional ? var.storage.gcnv.primary_zone : null
+  gcnv_replica_zone = local.gcnv_regional ? var.storage.gcnv.replica_zone : null
+  gcnv_root_volume = var.storage.gcnv.enabled ? one([
+    for volume in data.netapp-ontap_volumes.gcnv[0].storage_volumes : volume
+    if endswith(lower(volume.name), "_root")
+    && volume.nas.junction_path == "/"
+    && lower(volume.state) == "online"
+    && lower(volume.type) == "rw"
+  ]) : null
+}
+
+data "google_compute_zones" "gcnv" {
+  count = local.gcnv_zone_lookup ? 1 : 0
+
+  project = var.project
+  region  = local.region
+}
+
+resource "google_netapp_storage_pool" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  name         = var.deploy_id
+  location     = local.gcnv_location
+  zone         = local.gcnv_primary_zone
+  replica_zone = local.gcnv_replica_zone
+  # ONTAP-mode is only supported by Flex Unified.
+  service_level = "FLEX"
+  capacity_gib  = tostring(var.storage.gcnv.pool_capacity_gib)
+
+  # The API requires a relative network ID.
+  network = google_compute_network.vpc_network.id
+  type    = "UNIFIED"
+  mode    = "ONTAP"
+
+  depends_on = [google_compute_network_peering_routes_config.gcnv[0]]
+
+  lifecycle {
+    precondition {
+      condition = !local.gcnv_regional || (
+        can(regex("^${local.region}-[a-z]$", local.gcnv_primary_zone)) &&
+        can(regex("^${local.region}-[a-z]$", local.gcnv_replica_zone)) &&
+        local.gcnv_replica_zone != local.gcnv_primary_zone
+      )
+      error_message = "Regional GCNV pools require distinct primary_zone and replica_zone values in the deployment region."
+    }
+
+    # Preserve a zone switch performed by GCNV failover.
+    ignore_changes = [zone, replica_zone]
+  }
+}
+
+resource "terraform_data" "gcnv_ontap_ready" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  input = {
+    project      = var.project
+    location     = google_netapp_storage_pool.gcnv[0].location
+    storage_pool = google_netapp_storage_pool.gcnv[0].name
+    script       = "${path.module}/scripts/wait_gcnv_ontap_ready.py"
+  }
+  triggers_replace = [google_netapp_storage_pool.gcnv[0].id]
+
+  provisioner "local-exec" {
+    environment = {
+      GCNV_READINESS_SCRIPT = self.input.script
+      GCNV_PROJECT          = self.input.project
+      GCNV_LOCATION         = self.input.location
+      GCNV_STORAGE_POOL     = self.input.storage_pool
+    }
+
+    command = <<-EOF
+      python3 "$GCNV_READINESS_SCRIPT" \
+        --project "$GCNV_PROJECT" \
+        --location "$GCNV_LOCATION" \
+        --storage-pool "$GCNV_STORAGE_POOL"
+    EOF
+  }
+}
+
+data "netapp-ontap_volumes" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  cx_profile_name = var.deploy_id
+
+  depends_on = [terraform_data.gcnv_ontap_ready]
+}
+
+resource "netapp-ontap_nfs_export_policy_rule" "gcnv_node_access" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  cx_profile_name    = var.deploy_id
+  svm_name           = local.gcnv_root_volume.svm_name
+  export_policy_name = local.gcnv_root_volume.nas.export_policy_name
+  clients_match      = [google_compute_subnetwork.default.ip_cidr_range]
+  protocols          = ["nfs"]
+  ro_rule            = ["any"]
+  rw_rule            = ["any"]
+  superuser          = ["none"]
+}
+
+# Delete Trident-owned volumes before Terraform deletes their pool.
+resource "terraform_data" "gcnv_volume_cleanup" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  input = {
+    project      = var.project
+    location     = google_netapp_storage_pool.gcnv[0].location
+    storage_pool = google_netapp_storage_pool.gcnv[0].name
+    script       = "${path.module}/scripts/delete_gcnv_ontap_volumes.py"
+  }
+  triggers_replace = [google_netapp_storage_pool.gcnv[0].id]
+
+  provisioner "local-exec" {
+    when = destroy
+
+    environment = {
+      GCNV_CLEANUP_SCRIPT = self.input.script
+      GCNV_PROJECT        = self.input.project
+      GCNV_LOCATION       = self.input.location
+      GCNV_STORAGE_POOL   = self.input.storage_pool
+    }
+
+    command = <<-EOF
+      python3 "$GCNV_CLEANUP_SCRIPT" \
+        --project "$GCNV_PROJECT" \
+        --location "$GCNV_LOCATION" \
+        --storage-pool "$GCNV_STORAGE_POOL"
+    EOF
+  }
+}

--- a/network.tf
+++ b/network.tf
@@ -29,3 +29,33 @@ resource "google_compute_router_nat" "nat" {
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
+
+# GCNV requires at least a /24 PSA range; GCP selects the address.
+resource "google_compute_global_address" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  name          = "${var.deploy_id}-gcnv"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 24
+  network       = google_compute_network.vpc_network.self_link
+}
+
+resource "google_service_networking_connection" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  network                 = google_compute_network.vpc_network.self_link
+  service                 = "netapp.servicenetworking.goog"
+  reserved_peering_ranges = [google_compute_global_address.gcnv[0].name]
+}
+
+resource "google_compute_network_peering_routes_config" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  peering = google_service_networking_connection.gcnv[0].peering
+  network = google_compute_network.vpc_network.name
+
+  # Propagate routes across the NetApp service peering.
+  import_custom_routes = true
+  export_custom_routes = true
+}

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -6,10 +6,14 @@ locals {
 resource "google_container_node_pool" "node_pools" {
   for_each = local.node_pools
 
-  name           = each.key
-  location       = google_container_cluster.domino_cluster.location
-  cluster        = google_container_cluster.domino_cluster.name
-  node_locations = length(each.value.node_locations) != 0 ? each.value.node_locations : google_container_cluster.domino_cluster.node_locations
+  name     = each.key
+  location = google_container_cluster.domino_cluster.location
+  cluster  = google_container_cluster.domino_cluster.name
+  node_locations = length(each.value.node_locations) != 0 ? each.value.node_locations : (
+    var.storage.gcnv.enabled && !local.gcnv_regional && contains(["compute", "platform"], each.key)
+    ? [local.gcnv_location]
+    : google_container_cluster.domino_cluster.node_locations
+  )
 
   initial_node_count = each.value.initial_count
   max_pods_per_node  = each.value.max_pods

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,3 +78,16 @@ output "nfs_instance" {
   }
   description = "Domino Google Cloud Filestore instance, name and ip_address"
 }
+
+output "gcnv" {
+  value = {
+    project_number        = var.storage.gcnv.enabled ? data.google_project.domino.number : null
+    location              = var.storage.gcnv.enabled ? local.gcnv_location : null
+    storage_pool_name     = var.storage.gcnv.enabled ? google_netapp_storage_pool.gcnv[0].name : null
+    service_account_email = var.storage.gcnv.enabled ? google_service_account.gcnv[0].email : null
+    client_cidr           = var.storage.gcnv.enabled ? google_compute_subnetwork.default.ip_cidr_range : null
+    root_volume_name      = var.storage.gcnv.enabled ? local.gcnv_root_volume.name : null
+    export_policy_name    = var.storage.gcnv.enabled ? local.gcnv_root_volume.nas.export_policy_name : null
+  }
+  description = "GCNV ONTAP-mode pool and Trident service account."
+}

--- a/pytests/fixtures/defaults.yaml
+++ b/pytests/fixtures/defaults.yaml
@@ -79,6 +79,13 @@ configs:
           filestore:
             capacity: 1024
             enabled: true
+          gcnv:
+            enabled: false
+            pool_capacity_gib: 1024
+            trident_namespace: trident
+            regional: false
+            primary_zone: null
+            replica_zone: null
           gcs:
             force_destroy_on_deletion: false
           nfs_instance:
@@ -99,6 +106,13 @@ configs:
       nfs_instance_ip: ${module.gke_cluster.nfs_instance.ip_address}
       nfs_instance_path: ${module.gke_cluster.nfs_instance.nfs_path}
       gcr_credential_refresher: ${module.gke_cluster.gcr_credential_refresher}
+      gcnv_project_number: ${module.gke_cluster.gcnv.project_number}
+      gcnv_location: ${module.gke_cluster.gcnv.location}
+      gcnv_storage_pool_name: ${module.gke_cluster.gcnv.storage_pool_name}
+      gcnv_service_account_email: ${module.gke_cluster.gcnv.service_account_email}
+      gcnv_client_cidr: ${module.gke_cluster.gcnv.client_cidr}
+      gcnv_root_volume_name: ${module.gke_cluster.gcnv.root_volume_name}
+      gcnv_export_policy_name: ${module.gke_cluster.gcnv.export_policy_name}
     remote_module_refs: null
 module_id: gke
 version: '1.0'

--- a/pytests/test_delete_gcnv_ontap_volumes.py
+++ b/pytests/test_delete_gcnv_ontap_volumes.py
@@ -1,0 +1,679 @@
+import json
+import subprocess
+import sys
+from email.message import Message
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.delete_gcnv_ontap_volumes import (  # noqa: E402
+    CleanupError,
+    TransientRequestError,
+    _access_token,
+    _request_json,
+    build_ontap_api_url,
+    cleanup,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+class FakeOpener:
+    def __init__(self, get_payloads, mutation_payloads=None):
+        self.get_payloads = iter(get_payloads)
+        self.mutation_payloads = iter(mutation_payloads or [])
+        self.requests = []
+        self.request_objects = []
+
+    def __call__(self, request, timeout):
+        self.requests.append((request.method, request.full_url, timeout))
+        self.request_objects.append(request)
+        if request.method == "GET":
+            payload = next(self.get_payloads)
+            if isinstance(payload, Exception):
+                raise payload
+            return FakeResponse(payload)
+        payload = next(self.mutation_payloads, {})
+        if isinstance(payload, Exception):
+            raise payload
+        return FakeResponse(payload)
+
+
+class TestDeleteGCNVOntapVolumes(TestCase):
+    def test_builds_an_exact_pool_qualified_url(self):
+        self.assertEqual(
+            build_ontap_api_url("project-name", "us-east4-a", "deploy/name"),
+            "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+            "storagePools/deploy%2Fname/ontap/api",
+        )
+
+    def test_preserves_root_and_deletes_every_non_root_volume(self):
+        initial = {
+            "body": {
+                "records": [
+                    {
+                        "uuid": "root-uuid",
+                        "name": "svm_root",
+                        "nas": {"path": "/"},
+                        "is_svm_root": True,
+                        "state": "online",
+                        "type": "rw",
+                    },
+                    {
+                        "uuid": "online-uuid",
+                        "name": "trident-online",
+                        "nas": {"path": "/trident-online"},
+                        "state": "online",
+                        "type": "rw",
+                    },
+                    {
+                        "uuid": "offline-uuid",
+                        "name": "trident-offline",
+                        "nas": {"path": "/trident-offline"},
+                        "state": "offline",
+                        "type": "dp",
+                    },
+                ]
+            }
+        }
+        only_root = {"body": {"records": [initial["body"]["records"][0]]}}
+        opener = FakeOpener([initial, only_root])
+
+        cleanup(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        prefix = (
+            "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+            "storagePools/deployment/ontap/api/storage/volumes"
+        )
+        self.assertEqual(
+            [(method, url) for method, url, _ in opener.requests],
+            [
+                ("GET", f"{prefix}?ontap_fields=uuid%2Cname%2Cnas.path%2Cis_svm_root&max_records=10000"),
+                ("PATCH", f"{prefix}/online-uuid"),
+                ("DELETE", f"{prefix}/online-uuid?force=true"),
+                ("PATCH", f"{prefix}/offline-uuid"),
+                ("DELETE", f"{prefix}/offline-uuid?force=true"),
+                ("GET", f"{prefix}?ontap_fields=uuid%2Cname%2Cnas.path%2Cis_svm_root&max_records=10000"),
+            ],
+        )
+        for method, url, _ in opener.requests:
+            if method == "GET":
+                self.assertIn("ontap_fields=uuid%2Cname%2Cnas.path%2Cis_svm_root", url)
+                self.assertIn("max_records=10000", url)
+        patch_requests = [request for request in opener.request_objects if request.method == "PATCH"]
+        self.assertEqual(
+            [json.loads(request.data) for request in patch_requests],
+            [{"body": {"nas": {"path": ""}}}, {"body": {"nas": {"path": ""}}}],
+        )
+        self.assertTrue(all(request.get_header("Content-type") == "application/json" for request in patch_requests))
+
+    def test_malformed_list_response_fails_before_deleting_anything(self):
+        opener = FakeOpener([{"body": {}}])
+
+        with self.assertRaisesRegex(CleanupError, "body.records"):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+            )
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_missing_uuid_fails_before_deleting_anything(self):
+        opener = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [
+                            {"uuid": "root-uuid", "nas": {"path": "/"}},
+                            {"name": "unsafe", "nas": {"path": "/unsafe"}},
+                            {"uuid": "otherwise-valid", "nas": {"path": "/valid"}},
+                        ]
+                    }
+                }
+            ]
+        )
+
+        with self.assertRaisesRegex(CleanupError, "non-root volume UUID"):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+            )
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_follows_pagination_before_deleting_anything(self):
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [root, {"uuid": "one", "nas": {"path": "/one"}}],
+                        "_links": {
+                            "next": {
+                                "href": "/api/storage/volumes?" "fields=uuid,name,nas.path,is_svm_root&start.uuid=two"
+                            }
+                        },
+                    }
+                },
+                {"body": {"records": [{"uuid": "two", "nas": {"path": "/two"}}]}},
+                {"body": {"records": [root]}},
+            ]
+        )
+
+        cleanup(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(
+            [request[0] for request in opener.requests],
+            ["GET", "GET", "PATCH", "DELETE", "PATCH", "DELETE", "GET"],
+        )
+        self.assertEqual(
+            opener.requests[1][1],
+            "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+            "storagePools/deployment/ontap/api/storage/volumes?"
+            "ontap_fields=uuid%2Cname%2Cnas.path%2Cis_svm_root&start.uuid=two",
+        )
+
+    def test_rejects_escaping_pagination_before_deleting_anything(self):
+        opener = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [{"uuid": "one", "nas": {"path": "/one"}}],
+                        "_links": {
+                            "next": {
+                                "href": "/api/storage/volumes/../../../../storagePools/other/"
+                                "ontap/api/storage/volumes?start.uuid=two"
+                            }
+                        },
+                    }
+                }
+            ]
+        )
+
+        with self.assertRaisesRegex(CleanupError, "escaped"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_rejects_malformed_and_cyclic_pagination(self):
+        malformed = FakeOpener([{"body": {"records": [], "_links": {"next": {"href": 123}}}}])
+        with self.assertRaisesRegex(CleanupError, "non-empty string"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=malformed)
+
+        cyclic = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [],
+                        "_links": {"next": {"href": "/api/storage/volumes?fields=uuid"}},
+                    }
+                },
+                {
+                    "body": {
+                        "records": [],
+                        "_links": {"next": {"href": "/api/storage/volumes?fields=uuid"}},
+                    }
+                },
+            ]
+        )
+        with self.assertRaisesRegex(CleanupError, "cycle"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=cyclic)
+
+    def test_missing_junction_path_is_treated_as_non_root(self):
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [
+                            root,
+                            {"uuid": "unmounted", "name": "unmounted", "is_svm_root": False},
+                        ]
+                    }
+                },
+                {"body": {"records": [root]}},
+            ]
+        )
+
+        cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+        self.assertIn(
+            (
+                "DELETE",
+                "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+                "storagePools/deployment/ontap/api/storage/volumes/unmounted?force=true",
+                30,
+            ),
+            opener.requests,
+        )
+
+    def test_deletes_volume_created_while_cleanup_is_polling(self):
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {"body": {"records": [root, {"uuid": "one", "nas": {"path": "/one"}}]}},
+                {
+                    "body": {
+                        "records": [
+                            root,
+                            {"uuid": "one", "nas": {"path": "/one"}},
+                            {"uuid": "two", "nas": {"path": "/two"}},
+                        ]
+                    }
+                },
+                {"body": {"records": [root]}},
+            ]
+        )
+
+        cleanup(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        delete_urls = [url for method, url, _ in opener.requests if method == "DELETE"]
+        self.assertEqual(len(delete_urls), 2)
+        self.assertTrue(delete_urls[0].endswith("/one?force=true"))
+        self.assertTrue(delete_urls[1].endswith("/two?force=true"))
+
+    def test_waits_for_unmount_and_delete_jobs(self):
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {"body": {"records": [root, {"uuid": "one", "nas": {"path": "/one"}}]}},
+                {"rawResponse": {"state": "running"}},
+                {"rawResponse": {"state": "success"}},
+                {"rawResponse": {"state": "success"}},
+                {"body": {"records": [root]}},
+            ],
+            mutation_payloads=[
+                {"body": {"job": {"uuid": "unmount-job"}}},
+                {"body": {"job": {"uuid": "delete-job"}}},
+            ],
+        )
+
+        cleanup(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        api = (
+            "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+            "storagePools/deployment/ontap/api"
+        )
+        self.assertEqual(
+            [(method, url) for method, url, _ in opener.requests],
+            [
+                ("GET", f"{api}/storage/volumes?ontap_fields=uuid%2Cname%2Cnas.path%2Cis_svm_root&max_records=10000"),
+                ("PATCH", f"{api}/storage/volumes/one"),
+                ("GET", f"{api}/cluster/jobs/unmount-job"),
+                ("GET", f"{api}/cluster/jobs/unmount-job"),
+                ("DELETE", f"{api}/storage/volumes/one?force=true"),
+                ("GET", f"{api}/cluster/jobs/delete-job"),
+                ("GET", f"{api}/storage/volumes?ontap_fields=uuid%2Cname%2Cnas.path%2Cis_svm_root&max_records=10000"),
+            ],
+        )
+
+    def test_concurrent_volume_deletion_during_unmount_is_idempotent(self):
+        url = "https://netapp.googleapis.com/"
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {"body": {"records": [root, {"uuid": "one", "nas": {"path": "/one"}}]}},
+                {"body": {"records": [root]}},
+            ],
+            mutation_payloads=[
+                HTTPError(url, 404, "Not Found", Message(), None),
+                HTTPError(url, 404, "Not Found", Message(), None),
+            ],
+        )
+
+        cleanup(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(
+            [method for method, _, _ in opener.requests],
+            ["GET", "PATCH", "DELETE", "GET"],
+        )
+
+    def test_job_failure_stops_before_delete(self):
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {"body": {"records": [root, {"uuid": "one", "nas": {"path": "/one"}}]}},
+                {"rawResponse": {"state": "failure", "message": "unmount blocked"}},
+            ],
+            mutation_payloads=[{"body": {"job": {"uuid": "unmount-job"}}}],
+        )
+
+        with self.assertRaisesRegex(CleanupError, "unmount blocked"):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+            )
+
+        self.assertNotIn("DELETE", [method for method, _, _ in opener.requests])
+
+    def test_job_timeout_stops_before_delete(self):
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {"body": {"records": [root, {"uuid": "one", "nas": {"path": "/one"}}]}},
+                {"rawResponse": {"state": "running"}},
+            ],
+            mutation_payloads=[{"body": {"job": {"uuid": "unmount-job"}}}],
+        )
+
+        with self.assertRaisesRegex(CleanupError, "Timed out"):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+                monotonic=iter([0.0, 2.0]).__next__,
+                timeout_seconds=1.0,
+            )
+
+        self.assertNotIn("DELETE", [method for method, _, _ in opener.requests])
+
+    def test_retries_parent_after_deleting_its_clone(self):
+        url = "https://netapp.googleapis.com/"
+        root = {"uuid": "root", "nas": {"path": "/"}}
+        opener = FakeOpener(
+            [
+                {
+                    "rawResponse": {
+                        "records": [
+                            root,
+                            {"uuid": "parent", "nas": {"path": "/parent"}},
+                            {"uuid": "clone", "nas": {"path": "/clone"}},
+                        ]
+                    }
+                },
+                {"body": {"records": [root, {"uuid": "parent", "is_svm_root": False}]}},
+                {"body": {"records": [root]}},
+            ],
+            mutation_payloads=[
+                {},
+                HTTPError(url, 409, "volume has a clone", Message(), None),
+                {},
+                {},
+                {},
+            ],
+        )
+
+        cleanup(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        delete_urls = [url for method, url, _ in opener.requests if method == "DELETE"]
+        prefix = (
+            "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+            "storagePools/deployment/ontap/api/storage/volumes"
+        )
+        self.assertEqual(
+            delete_urls,
+            [
+                f"{prefix}/parent?force=true",
+                f"{prefix}/clone?force=true",
+                f"{prefix}/parent?force=true",
+            ],
+        )
+
+    def test_already_absent_pool_is_success(self):
+        url = "https://netapp.googleapis.com/"
+        opener = FakeOpener([HTTPError(url, 404, "Not Found", Message(), None)])
+
+        cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_second_page_404_fails_instead_of_claiming_pool_is_absent(self):
+        url = "https://netapp.googleapis.com/"
+        opener = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [],
+                        "_links": {"next": {"href": "/api/storage/volumes?start.uuid=two"}},
+                    }
+                },
+                HTTPError(url, 404, "Not Found", Message(), None),
+            ]
+        )
+
+        with self.assertRaisesRegex(CleanupError, "failed"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+    def test_missing_root_classification_fails_before_deleting(self):
+        opener = FakeOpener([{"body": {"records": [{"uuid": "unknown"}]}}])
+
+        with self.assertRaisesRegex(CleanupError, "nas.path or is_svm_root"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_non_boolean_root_flag_fails_before_deleting(self):
+        opener = FakeOpener([{"body": {"records": [{"uuid": "root", "is_svm_root": "true"}]}}])
+
+        with self.assertRaisesRegex(CleanupError, "must be a boolean"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_missing_or_duplicate_root_fails_before_deleting(self):
+        no_root = FakeOpener([{"body": {"records": [{"uuid": "data", "nas": {"path": "/data"}}]}}])
+        with self.assertRaisesRegex(CleanupError, "exactly one SVM root"):
+            cleanup("project-name", "us-east4-a", "deployment", token="token", opener=no_root)
+        self.assertEqual([request[0] for request in no_root.requests], ["GET"])
+
+        duplicate_root = FakeOpener(
+            [
+                {
+                    "body": {
+                        "records": [
+                            {"uuid": "root-one", "nas": {"path": "/"}},
+                            {"uuid": "root-two", "is_svm_root": True},
+                        ]
+                    }
+                }
+            ]
+        )
+        with self.assertRaisesRegex(CleanupError, "found 2"):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=duplicate_root,
+            )
+        self.assertEqual([request[0] for request in duplicate_root.requests], ["GET"])
+
+    def test_empty_volume_inventory_is_already_clean(self):
+        opener = FakeOpener([{"body": {"records": []}}])
+
+        cleanup("project-name", "us-east4-a", "deployment", token="token", opener=opener)
+
+        self.assertEqual([request[0] for request in opener.requests], ["GET"])
+
+    def test_delete_404_is_idempotent_and_non_404_http_error_fails(self):
+        url = "https://netapp.googleapis.com/"
+
+        def not_found(*_, **__):
+            raise HTTPError(url, 404, "Not Found", Message(), None)
+
+        def forbidden(*_, **__):
+            raise HTTPError(url, 403, "Forbidden", Message(), None)
+
+        self.assertEqual(_request_json(not_found, "token", "DELETE", url), {})
+        with self.assertRaisesRegex(CleanupError, "403"):
+            _request_json(forbidden, "token", "DELETE", url)
+
+    def test_retries_one_transient_request(self):
+        url = "https://netapp.googleapis.com/"
+        opener = FakeOpener(
+            [
+                HTTPError(url, 503, "Unavailable", Message(), None),
+                {"body": {"records": []}},
+            ]
+        )
+        sleeps: list[float] = []
+
+        self.assertEqual(
+            _request_json(opener, "token", "GET", url, sleep=sleeps.append),
+            {"body": {"records": []}},
+        )
+        self.assertEqual(len(opener.requests), 2)
+        self.assertEqual(sleeps, [1])
+
+    def test_exhausted_transient_request_raises(self):
+        url = "https://netapp.googleapis.com/"
+        opener = FakeOpener(
+            [
+                HTTPError(url, 503, "Unavailable", Message(), None),
+                HTTPError(url, 503, "Unavailable", Message(), None),
+            ]
+        )
+
+        with self.assertRaisesRegex(TransientRequestError, "503"):
+            _request_json(opener, "token", "GET", url, sleep=lambda _: None)
+
+        self.assertEqual(len(opener.requests), 2)
+
+    @patch(
+        "scripts.delete_gcnv_ontap_volumes.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, ["gcloud"], stderr="permission denied"),
+    )
+    def test_access_token_error_includes_stderr(self, _run):
+        with self.assertRaisesRegex(CleanupError, "permission denied"):
+            _access_token()
+
+    @patch(
+        "scripts.delete_gcnv_ontap_volumes.subprocess.run",
+        return_value=Mock(stdout="token\n"),
+    )
+    def test_access_token_uses_application_default_credentials(self, run):
+        self.assertEqual(_access_token(), "token")
+        run.assert_called_once_with(
+            ["gcloud", "auth", "application-default", "print-access-token"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_times_out_if_a_deleted_volume_remains(self):
+        volume_response = {
+            "body": {
+                "records": [
+                    {"uuid": "root-uuid", "nas": {"path": "/"}},
+                    {"uuid": "stuck-uuid", "nas": {"path": "/stuck"}},
+                ]
+            }
+        }
+        opener = FakeOpener([volume_response, volume_response])
+
+        with self.assertRaisesRegex(CleanupError, "Timed out"):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+                monotonic=iter([0.0, 2.0]).__next__,
+                timeout_seconds=1.0,
+            )
+
+    def test_timeout_includes_latest_delete_errors(self):
+        url = "https://netapp.googleapis.com/"
+        volume_response = {
+            "body": {
+                "records": [
+                    {"uuid": "root-uuid", "name": "root", "nas": {"path": "/"}},
+                    {"uuid": "in-flight", "name": "stuck-a", "nas": {"path": ""}},
+                    {"uuid": "delete-error", "name": "stuck-b", "nas": {"path": ""}},
+                ]
+            }
+        }
+        conflict = HTTPError(url, 409, "volume has a clone", Message(), None)
+        opener = FakeOpener(
+            [volume_response, volume_response],
+            mutation_payloads=[{}, conflict, conflict],
+        )
+
+        with self.assertRaisesRegex(
+            CleanupError,
+            "Timed out.*stuck-a, stuck-b.*delete-error:.*409",
+        ):
+            cleanup(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+                monotonic=iter([0.0, 2.0]).__next__,
+                timeout_seconds=1.0,
+            )

--- a/pytests/test_generator.py
+++ b/pytests/test_generator.py
@@ -131,7 +131,10 @@ class TestGenerator(TestCase):
             "filestore": {"enabled": True, "capacity": 1024},
             "nfs_instance": {"enabled": True, "capacity": 100},
         }
-        with self.assertRaisesRegex(ValueError, "Cannot enable both filestore and nfs instance"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Multiple shared stores enabled: filestore, nfs_instance",
+        ):
             GKEStorage(**values)
 
         values["filestore"]["enabled"] = False
@@ -140,6 +143,54 @@ class TestGenerator(TestCase):
         values["filestore"]["enabled"] = False
         values["nfs_instance"]["enabled"] = True
         GKEStorage(**values)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Multiple shared stores enabled: filestore, gcnv",
+        ):
+            GKEStorage(filestore={"enabled": True, "capacity": 1024}, gcnv={"enabled": True})
+        with self.assertRaisesRegex(
+            ValueError,
+            "Multiple shared stores enabled: nfs_instance, gcnv",
+        ):
+            GKEStorage(
+                filestore={"enabled": False, "capacity": 1024},
+                nfs_instance={"enabled": True, "capacity": 100},
+                gcnv={"enabled": True},
+            )
+
+    def test_gcnv_storage(self):
+        tf_module = self.get_tfmodule()
+        gke_cluster = tf_module.configs["main"].module.gke_cluster
+        gke_cluster.storage.filestore.enabled = False
+        gke_cluster.storage.gcnv.enabled = True
+        gke_cluster.storage.gcnv.trident_namespace = "custom-trident"
+        gke_cluster.storage.gcnv.regional = True
+        gke_cluster.storage.gcnv.primary_zone = "us-west1-b"
+        gke_cluster.storage.gcnv.replica_zone = "us-west1-c"
+
+        for module in tf_module.configs.values():
+            self.assertTrue(module.module.gke_cluster.storage.gcnv.regional)
+            self.assertEqual(module.module.gke_cluster.storage.gcnv.trident_namespace, "custom-trident")
+            self.assertEqual(module.module.gke_cluster.storage.gcnv.primary_zone, "us-west1-b")
+            self.assertEqual(module.module.gke_cluster.storage.gcnv.replica_zone, "us-west1-c")
+            validate(module)
+
+    def test_gcnv_output_includes_all_fields(self):
+        tf_module = self.get_tfmodule()
+        for module in tf_module.configs.values():
+            self.assertEqual(
+                module.output.gcnv_client_cidr,
+                "${module.gke_cluster.gcnv.client_cidr}",
+            )
+            self.assertEqual(
+                module.output.gcnv_root_volume_name,
+                "${module.gke_cluster.gcnv.root_volume_name}",
+            )
+            self.assertEqual(
+                module.output.gcnv_export_policy_name,
+                "${module.gke_cluster.gcnv.export_policy_name}",
+            )
 
     def test_upgrade(self):
         with open("fixtures/defaults.yaml") as f:

--- a/pytests/test_module_contract.py
+++ b/pytests/test_module_contract.py
@@ -1,0 +1,196 @@
+from pathlib import Path
+from unittest import TestCase
+
+import hcl2
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_hcl(name):
+    with (ROOT / name).open() as source:
+        return hcl2.load(source)
+
+
+def named_block(config, block_type, resource_type, name):
+    for block in config[block_type]:
+        if resource_type in block and name in block[resource_type]:
+            return block[resource_type][name]
+    raise AssertionError(f"Missing {block_type} {resource_type}.{name}")
+
+
+def resource(config, resource_type, name):
+    return named_block(config, "resource", resource_type, name)
+
+
+def block(config, block_type, name):
+    for item in config[block_type]:
+        if name in item:
+            return item[name]
+    raise AssertionError(f"Missing {block_type} {name}")
+
+
+class TestModuleContract(TestCase):
+    def test_gcnv_range_is_automatically_allocated(self):
+        address = resource(
+            load_hcl("network.tf"),
+            '"google_compute_global_address"',
+            '"gcnv"',
+        )
+
+        self.assertNotIn("address", address)
+        self.assertEqual(address["prefix_length"], 24)
+
+    def test_regional_gcnv_uses_the_first_declared_zone(self):
+        main = load_hcl("main.tf")
+        gcnv = load_hcl("gcnv.tf")
+        zones = named_block(gcnv, "data", '"google_compute_zones"', '"gcnv"')
+
+        self.assertEqual(
+            zones["count"],
+            "${local.gcnv_zone_lookup ? 1 : 0}",
+        )
+        self.assertEqual(zones["project"], "${var.project}")
+        self.assertEqual(zones["region"], "${local.region}")
+        self.assertNotIn("status", zones)
+        self.assertEqual(
+            main["locals"][0]["zone"],
+            '${local.is_regional ? format("%s-a", var.location) : var.location}',
+        )
+        self.assertEqual(
+            gcnv["locals"][0]["gcnv_zone_lookup"],
+            "${var.storage.gcnv.enabled && !local.gcnv_regional && local.is_regional}",
+        )
+        self.assertEqual(
+            gcnv["locals"][0]["gcnv_location"],
+            "${local.gcnv_zone_lookup ? sort(data.google_compute_zones.gcnv[0].names)[0] : "
+            "(local.gcnv_regional ? local.region : local.zone)}",
+        )
+
+    def test_zonal_gcnv_defaults_domino_node_pools_to_its_zone(self):
+        node_pool = resource(
+            load_hcl("node_pools.tf"),
+            '"google_container_node_pool"',
+            '"node_pools"',
+        )
+
+        self.assertEqual(
+            node_pool["node_locations"],
+            "${length(each.value.node_locations) != 0 ? each.value.node_locations : "
+            '(var.storage.gcnv.enabled && !local.gcnv_regional && contains(["compute", "platform"], each.key) '
+            "? [local.gcnv_location] : google_container_cluster.domino_cluster.node_locations)}",
+        )
+
+    def test_terraform_version_supports_terraform_data(self):
+        terraform = load_hcl("versions.tf")["terraform"][0]
+        self.assertEqual(terraform["required_version"], '">= 1.4"')
+
+    def test_gcnv_workload_identity_uses_configured_namespace(self):
+        binding = resource(
+            load_hcl("service-accounts.tf"),
+            '"google_service_account_iam_binding"',
+            '"gcnv"',
+        )
+        self.assertEqual(
+            binding["members"],
+            ['"serviceAccount:${var.project}.svc.id.goog[${var.storage.gcnv.trident_namespace}/trident-controller]"'],
+        )
+
+    def test_gcnv_service_account_uses_supported_roles(self):
+        custom_role = resource(
+            load_hcl("service-accounts.tf"),
+            '"google_project_iam_custom_role"',
+            '"gcnv"',
+        )
+        self.assertEqual(
+            custom_role["permissions"],
+            [
+                '"netapp.ontap.get"',
+                '"netapp.ontap.post"',
+                '"netapp.ontap.patch"',
+                '"netapp.ontap.delete"',
+            ],
+        )
+        viewer = resource(
+            load_hcl("service-accounts.tf"),
+            '"google_project_iam_member"',
+            '"gcnv_viewer"',
+        )
+        self.assertEqual(viewer["role"], '"roles/netapp.viewer"')
+        self.assertEqual(
+            viewer["member"],
+            '"serviceAccount:${google_service_account.gcnv[0].email}"',
+        )
+
+    def test_gcnv_owns_ontap_provider_and_root_export_rule(self):
+        required_providers = load_hcl("versions.tf")["terraform"][0]["required_providers"][0]
+        self.assertEqual(
+            required_providers["netapp-ontap"],
+            {
+                "source": '"NetApp/netapp-ontap"',
+                "version": '"2.7.0"',
+            },
+        )
+
+        provider = block(load_hcl("versions.tf"), "provider", '"netapp-ontap"')
+        self.assertEqual(
+            provider["connection_profiles"][0]["name"],
+            "${var.deploy_id}",
+        )
+        self.assertEqual(
+            provider["connection_profiles"][0]["google_netapp_unified_pool"],
+            {
+                "project_id": "${var.project}",
+                "location": "${local.gcnv_location}",
+                "storage_pool": "${var.deploy_id}",
+            },
+        )
+
+        gcnv = load_hcl("gcnv.tf")
+        readiness = resource(gcnv, '"terraform_data"', '"gcnv_ontap_ready"')
+        self.assertEqual(readiness["count"], "${var.storage.gcnv.enabled ? 1 : 0}")
+        self.assertEqual(
+            readiness["input"],
+            {
+                "project": "${var.project}",
+                "location": "${google_netapp_storage_pool.gcnv[0].location}",
+                "storage_pool": "${google_netapp_storage_pool.gcnv[0].name}",
+                "script": '"${path.module}/scripts/wait_gcnv_ontap_ready.py"',
+            },
+        )
+        provisioner = readiness["provisioner"][0]['"local-exec"']
+        self.assertIn('python3 "$GCNV_READINESS_SCRIPT"', provisioner["command"])
+
+        volumes = named_block(gcnv, "data", '"netapp-ontap_volumes"', '"gcnv"')
+        self.assertEqual(volumes["count"], "${var.storage.gcnv.enabled ? 1 : 0}")
+        self.assertEqual(volumes["cx_profile_name"], "${var.deploy_id}")
+        self.assertEqual(
+            volumes["depends_on"],
+            ["${terraform_data.gcnv_ontap_ready}"],
+        )
+        self.assertEqual(
+            gcnv["locals"][0]["gcnv_root_volume"],
+            '${var.storage.gcnv.enabled ? one([for volume in '
+            'data.netapp-ontap_volumes.gcnv[0].storage_volumes : volume '
+            'if endswith(lower(volume.name), "_root") '
+            '&& volume.nas.junction_path == "/" '
+            '&& lower(volume.state) == "online" '
+            '&& lower(volume.type) == "rw"]) : null}',
+        )
+
+        export_rule = resource(gcnv, '"netapp-ontap_nfs_export_policy_rule"', '"gcnv_node_access"')
+        self.assertEqual(export_rule["count"], "${var.storage.gcnv.enabled ? 1 : 0}")
+        self.assertEqual(export_rule["svm_name"], "${local.gcnv_root_volume.svm_name}")
+        self.assertEqual(
+            export_rule["export_policy_name"],
+            "${local.gcnv_root_volume.nas.export_policy_name}",
+        )
+
+        output = block(load_hcl("outputs.tf"), "output", '"gcnv"')["value"]
+        self.assertEqual(
+            output["root_volume_name"],
+            "${var.storage.gcnv.enabled ? local.gcnv_root_volume.name : null}",
+        )
+        self.assertEqual(
+            output["export_policy_name"],
+            "${var.storage.gcnv.enabled ? local.gcnv_root_volume.nas.export_policy_name : null}",
+        )

--- a/pytests/test_wait_gcnv_ontap_ready.py
+++ b/pytests/test_wait_gcnv_ontap_ready.py
@@ -1,0 +1,229 @@
+import json
+import sys
+from email.message import Message
+from pathlib import Path
+from unittest import TestCase
+from urllib.error import HTTPError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.delete_gcnv_ontap_volumes import CleanupError  # noqa: E402
+from scripts.wait_gcnv_ontap_ready import wait_until_ready  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+class FakeOpener:
+    def __init__(self, payloads):
+        self.payloads = iter(payloads)
+        self.requests = []
+
+    def __call__(self, request, timeout):
+        self.requests.append((request.method, request.full_url, timeout))
+        payload = next(self.payloads)
+        if isinstance(payload, Exception):
+            raise payload
+        return FakeResponse(payload)
+
+
+class Clock:
+    def __init__(self):
+        self.value = 0.0
+        self.sleeps = []
+
+    def monotonic(self):
+        return self.value
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.value += seconds
+
+
+def volume(name="svm_root", path="/", state="online", volume_type="rw"):
+    return {
+        "name": name,
+        "nas": {"path": path},
+        "is_svm_root": path == "/",
+        "state": state,
+        "type": volume_type,
+    }
+
+
+def inventory(*records):
+    return {"body": {"records": list(records)}}
+
+
+class TestWaitGCNVOntapReady(TestCase):
+    def test_returns_when_the_single_root_is_ready(self):
+        opener = FakeOpener([inventory(volume())])
+
+        wait_until_ready(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(
+            opener.requests,
+            [
+                (
+                    "GET",
+                    "https://netapp.googleapis.com/v1/projects/project-name/locations/us-east4-a/"
+                    "storagePools/deployment/ontap/api/storage/volumes?"
+                    "ontap_fields=name%2Cnas.path%2Cis_svm_root%2Cstate%2Ctype&max_records=10000",
+                    30,
+                )
+            ],
+        )
+
+    def test_polls_until_the_root_is_ready(self):
+        clock = Clock()
+        opener = FakeOpener([inventory(), inventory(volume())])
+
+        wait_until_ready(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=clock.sleep,
+            monotonic=clock.monotonic,
+        )
+
+        self.assertEqual(len(opener.requests), 2)
+        self.assertEqual(clock.sleeps, [5])
+
+    def test_retries_absent_pool_and_exhausted_transient_request(self):
+        url = "https://netapp.googleapis.com/"
+        clock = Clock()
+        opener = FakeOpener(
+            [
+                HTTPError(url, 404, "Not Found", Message(), None),
+                HTTPError(url, 503, "Unavailable", Message(), None),
+                HTTPError(url, 503, "Unavailable", Message(), None),
+                inventory(volume()),
+            ]
+        )
+
+        wait_until_ready(
+            "project-name",
+            "us-east4-a",
+            "deployment",
+            token="token",
+            opener=opener,
+            sleep=clock.sleep,
+            monotonic=clock.monotonic,
+        )
+
+        self.assertEqual(len(opener.requests), 4)
+        self.assertEqual(clock.sleeps, [5, 1, 5])
+
+    def test_timeout_reports_the_last_observed_root_count(self):
+        clock = Clock()
+        opener = FakeOpener([inventory()])
+
+        with self.assertRaisesRegex(CleanupError, "Timed out.*found 0 matching root volumes"):
+            wait_until_ready(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=clock.sleep,
+                monotonic=clock.monotonic,
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(len(opener.requests), 1)
+
+    def test_clamps_requests_and_sleeps_to_the_deadline(self):
+        clock = Clock()
+        opener = FakeOpener([inventory()])
+
+        with self.assertRaisesRegex(CleanupError, "Timed out"):
+            wait_until_ready(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=clock.sleep,
+                monotonic=clock.monotonic,
+                timeout_seconds=2,
+            )
+
+        self.assertEqual([timeout for _, _, timeout in opener.requests], [2])
+        self.assertEqual(clock.sleeps, [2])
+
+    def test_clamps_transient_retry_sleep_to_the_deadline(self):
+        clock = Clock()
+        url = "https://netapp.googleapis.com/"
+
+        class NearDeadlineOpener:
+            requests = []
+
+            def __call__(self, request, timeout):
+                self.requests.append((request.method, request.full_url, timeout))
+                clock.value += 1.75
+                raise HTTPError(url, 503, "Unavailable", Message(), None)
+
+        opener = NearDeadlineOpener()
+        with self.assertRaisesRegex(CleanupError, "Timed out"):
+            wait_until_ready(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=clock.sleep,
+                monotonic=clock.monotonic,
+                timeout_seconds=2,
+            )
+
+        self.assertEqual([timeout for _, _, timeout in opener.requests], [2])
+        self.assertEqual(clock.sleeps, [0.25])
+
+    def test_duplicate_roots_fail_immediately(self):
+        opener = FakeOpener([inventory(volume("one_root"), volume("two_root"))])
+
+        with self.assertRaisesRegex(CleanupError, "found 2 matching root volumes"):
+            wait_until_ready(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+            )
+
+        self.assertEqual(len(opener.requests), 1)
+
+    def test_malformed_inventory_fails_immediately(self):
+        opener = FakeOpener([inventory({"name": "svm_root", "nas": {"path": "/"}})])
+
+        with self.assertRaisesRegex(CleanupError, "state"):
+            wait_until_ready(
+                "project-name",
+                "us-east4-a",
+                "deployment",
+                token="token",
+                opener=opener,
+                sleep=lambda _: None,
+            )
+
+        self.assertEqual(len(opener.requests), 1)

--- a/scripts/delete_gcnv_ontap_volumes.py
+++ b/scripts/delete_gcnv_ontap_volumes.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Delete Trident-created ONTAP volumes before destroying a GCNV storage pool."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from collections.abc import Callable
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit
+from urllib.request import Request, urlopen
+
+
+class CleanupError(RuntimeError):
+    """Raised when GCNV volume cleanup cannot be completed safely."""
+
+
+class PoolAbsent(CleanupError):
+    """Raised when the exact storage-pool ONTAP endpoint no longer exists."""
+
+
+class TransientRequestError(CleanupError):
+    """Raised after a transient ONTAP request exhausts its retry."""
+
+
+def build_ontap_api_url(project: str, location: str, storage_pool: str) -> str:
+    """Return the ONTAP proxy URL scoped to exactly one GCNV storage pool."""
+    segments = (project, location, storage_pool)
+    if any(not segment for segment in segments):
+        raise CleanupError("project, location, and storage pool must all be non-empty")
+    escaped_project, escaped_location, escaped_pool = (quote(segment, safe="") for segment in segments)
+    return (
+        "https://netapp.googleapis.com/v1/"
+        f"projects/{escaped_project}/locations/{escaped_location}/storagePools/{escaped_pool}/ontap/api"
+    )
+
+
+def _access_token() -> str:
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "application-default", "print-access-token"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        stderr = getattr(error, "stderr", None)
+        detail = stderr.strip() if isinstance(stderr, str) and stderr.strip() else str(error)
+        raise CleanupError(f"could not obtain a gcloud access token: {detail}") from error
+    token = result.stdout.strip()
+    if not token:
+        raise CleanupError("gcloud returned an empty access token")
+    return token
+
+
+def _request_json(
+    opener: Callable[..., Any],
+    token: str,
+    method: str,
+    url: str,
+    *,
+    not_found_is_absent: bool = False,
+    json_body: dict[str, Any] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    deadline: float | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    data = None
+    if json_body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(json_body).encode()
+    request = Request(
+        url,
+        data=data,
+        method=method,
+        headers=headers,
+    )
+    for attempt in range(2):
+        request_timeout = 30.0
+        if deadline is not None:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                raise TransientRequestError(f"{method} {url} exceeded its deadline")
+            request_timeout = min(request_timeout, remaining)
+        try:
+            with opener(request, timeout=request_timeout) as response:
+                raw = response.read()
+            break
+        except HTTPError as error:
+            if error.code == 404:
+                if method == "GET" and not_found_is_absent:
+                    raise PoolAbsent(f"{method} {url} returned 404") from error
+                if method in {"PATCH", "DELETE"}:
+                    return {}
+            if error.code == 429 or 500 <= error.code < 600:
+                if attempt == 0:
+                    retry_delay = 1.0
+                    if deadline is not None:
+                        retry_delay = min(retry_delay, max(0.0, deadline - monotonic()))
+                    if retry_delay > 0:
+                        sleep(retry_delay)
+                    continue
+                raise TransientRequestError(f"{method} {url} failed after retry: {error}") from error
+            raise CleanupError(f"{method} {url} failed: {error}") from error
+        except Exception as error:
+            raise CleanupError(f"{method} {url} failed: {error}") from error
+
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise CleanupError(f"{method} {url} returned invalid JSON") from error
+    if not isinstance(payload, dict):
+        raise CleanupError(f"{method} {url} returned a non-object JSON response")
+    return payload
+
+
+def _ontap_body(payload: dict[str, Any]) -> dict[str, Any] | None:
+    body = payload.get("body")
+    if body is None:
+        body = payload.get("rawResponse")
+    return body if isinstance(body, dict) else None
+
+
+def _volume_page(payload: dict[str, Any]) -> tuple[list[dict[str, Any]], str | None]:
+    body = _ontap_body(payload)
+    if not isinstance(body, dict):
+        raise CleanupError("ONTAP volume response must contain a body.records array")
+    records = body.get("records")
+    if not isinstance(records, list) or any(not isinstance(record, dict) for record in records):
+        raise CleanupError("ONTAP volume response must contain a body.records array")
+    links = body.get("_links")
+    if links is None:
+        return records, None
+    if not isinstance(links, dict):
+        raise CleanupError("ONTAP volume response _links must be an object")
+    next_link = links.get("next")
+    if next_link is None:
+        return records, None
+    href = next_link.get("href") if isinstance(next_link, dict) else None
+    if not isinstance(href, str) or not href:
+        raise CleanupError("ONTAP volume response _links.next.href must be a non-empty string")
+    return records, href
+
+
+def _all_volume_records(
+    opener: Callable[..., Any],
+    token: str,
+    api_url: str,
+    first_url: str,
+    *,
+    first_not_found_is_absent: bool = False,
+    request_sleep: Callable[[float], None] = time.sleep,
+    request_deadline: float | None = None,
+    request_monotonic: Callable[[], float] = time.monotonic,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    next_url: str | None = first_url
+    visited: set[str] = set()
+    while next_url is not None:
+        if next_url in visited:
+            raise CleanupError("ONTAP volume pagination contains a cycle")
+        visited.add(next_url)
+        page_records, next_href = _volume_page(
+            _request_json(
+                opener,
+                token,
+                "GET",
+                next_url,
+                not_found_is_absent=first_not_found_is_absent and next_url == first_url,
+                sleep=request_sleep,
+                deadline=request_deadline,
+                monotonic=request_monotonic,
+            )
+        )
+        records.extend(page_records)
+        if next_href is None:
+            next_url = None
+        else:
+            parsed = urlsplit(next_href)
+            if (
+                parsed.scheme
+                or parsed.netloc
+                or parsed.path != "/api/storage/volumes"
+                or not parsed.query
+                or parsed.fragment
+            ):
+                raise CleanupError("ONTAP volume pagination escaped the exact storage-pool endpoint")
+            query = urlencode(
+                [
+                    ("ontap_fields" if key == "fields" else key, value)
+                    for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+                ]
+            )
+            next_url = f"{api_url}{parsed.path.removeprefix('/api')}?{query}"
+    return records
+
+
+def _wait_ontap_job(
+    opener: Callable[..., Any],
+    token: str,
+    api_url: str,
+    payload: dict[str, Any],
+    *,
+    sleep: Callable[[float], None],
+    monotonic: Callable[[], float],
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+) -> None:
+    body = _ontap_body(payload)
+    job = body.get("job") if body is not None else None
+    if job is None:
+        return
+    uuid = job.get("uuid") if isinstance(job, dict) else None
+    if not isinstance(uuid, str) or not uuid:
+        raise CleanupError("ONTAP job response must contain a non-empty job UUID")
+
+    deadline = monotonic() + timeout_seconds
+    job_url = f"{api_url}/cluster/jobs/{quote(uuid, safe='')}"
+    while True:
+        status = _ontap_body(_request_json(opener, token, "GET", job_url, sleep=sleep))
+        state = status.get("state") if status is not None else None
+        if state == "success":
+            return
+        if state == "failure":
+            message = (status or {}).get("message") or "unknown error"
+            raise CleanupError(f"ONTAP job {uuid} failed: {message}")
+        if monotonic() >= deadline:
+            raise CleanupError(f"Timed out waiting for ONTAP job {uuid}")
+        sleep(poll_interval_seconds)
+
+
+def _non_root_volumes(records: list[dict[str, Any]]) -> list[tuple[str, str, str | None]]:
+    if not records:
+        return []
+
+    candidates: list[tuple[str, str, str | None]] = []
+    root_count = 0
+    for record in records:
+        nas = record.get("nas")
+        path = nas.get("path") if isinstance(nas, dict) else None
+        is_svm_root = record.get("is_svm_root")
+        if is_svm_root is not None and not isinstance(is_svm_root, bool):
+            raise CleanupError("ONTAP volume is_svm_root must be a boolean when present")
+        if not isinstance(path, str) and not isinstance(is_svm_root, bool):
+            raise CleanupError("every ONTAP volume must contain nas.path or is_svm_root")
+        if is_svm_root is True or path == "/":
+            root_count += 1
+            continue
+
+        uuid = record.get("uuid")
+        if not isinstance(uuid, str) or not uuid:
+            raise CleanupError("every non-root volume UUID must be a non-empty string")
+        name = record.get("name")
+        candidates.append((uuid, name if isinstance(name, str) else uuid, path))
+    if root_count != 1:
+        raise CleanupError(f"expected exactly one SVM root volume, found {root_count}")
+    return candidates
+
+
+def cleanup(
+    project: str,
+    location: str,
+    storage_pool: str,
+    *,
+    token: str | None = None,
+    opener: Callable[..., Any] = urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    timeout_seconds: float = 600,
+    poll_interval_seconds: float = 5,
+) -> None:
+    """Delete all non-root ONTAP volumes in exactly one GCNV storage pool."""
+    api_url = build_ontap_api_url(project, location, storage_pool)
+    access_token = token or _access_token()
+    volumes_url = f"{api_url}/storage/volumes"
+    list_url = (
+        f"{volumes_url}?" f"{urlencode({'ontap_fields': 'uuid,name,nas.path,is_svm_root', 'max_records': 10000})}"
+    )
+    requested: set[str] = set()
+
+    def request_deletes(
+        candidates: list[tuple[str, str, str | None]],
+    ) -> tuple[set[str], dict[str, CleanupError]]:
+        newly_requested: set[str] = set()
+        errors: dict[str, CleanupError] = {}
+        for uuid, name, path in candidates:
+            if uuid in requested:
+                continue
+            print(f"Deleting GCNV ONTAP volume {name} ({uuid}) from storage pool {storage_pool}")
+            volume_url = f"{volumes_url}/{quote(uuid, safe='')}"
+            try:
+                if path:
+                    _wait_ontap_job(
+                        opener,
+                        access_token,
+                        api_url,
+                        _request_json(
+                            opener,
+                            access_token,
+                            "PATCH",
+                            volume_url,
+                            json_body={"body": {"nas": {"path": ""}}},
+                            sleep=sleep,
+                        ),
+                        sleep=sleep,
+                        monotonic=monotonic,
+                        timeout_seconds=timeout_seconds,
+                        poll_interval_seconds=poll_interval_seconds,
+                    )
+                _wait_ontap_job(
+                    opener,
+                    access_token,
+                    api_url,
+                    _request_json(
+                        opener,
+                        access_token,
+                        "DELETE",
+                        f"{volume_url}?{urlencode({'force': 'true'})}",
+                        sleep=sleep,
+                    ),
+                    sleep=sleep,
+                    monotonic=monotonic,
+                    timeout_seconds=timeout_seconds,
+                    poll_interval_seconds=poll_interval_seconds,
+                )
+            except CleanupError as error:
+                errors[uuid] = error
+            else:
+                requested.add(uuid)
+                newly_requested.add(uuid)
+        return newly_requested, errors
+
+    def raise_if_stalled(
+        candidates: list[tuple[str, str, str | None]],
+        newly_requested: set[str],
+        errors: dict[str, CleanupError],
+    ) -> None:
+        in_flight = any(uuid in requested for uuid, _, _ in candidates)
+        if errors and not newly_requested and not in_flight:
+            if len(errors) == 1:
+                raise next(iter(errors.values()))
+            detail = "; ".join(f"{uuid}: {error}" for uuid, error in errors.items())
+            raise CleanupError(f"could not delete ONTAP volumes: {detail}")
+
+    try:
+        candidates = _non_root_volumes(
+            _all_volume_records(
+                opener,
+                access_token,
+                api_url,
+                list_url,
+                first_not_found_is_absent=True,
+                request_sleep=sleep,
+            )
+        )
+        newly_requested, errors = request_deletes(candidates)
+        raise_if_stalled(candidates, newly_requested, errors)
+    except PoolAbsent:
+        print(f"GCNV storage pool {storage_pool} is already absent")
+        return
+
+    deadline = monotonic() + timeout_seconds
+    while candidates:
+        try:
+            candidates = _non_root_volumes(
+                _all_volume_records(
+                    opener,
+                    access_token,
+                    api_url,
+                    list_url,
+                    first_not_found_is_absent=True,
+                    request_sleep=sleep,
+                )
+            )
+        except PoolAbsent:
+            print(f"GCNV storage pool {storage_pool} is already absent")
+            return
+        if not candidates:
+            break
+        newly_requested, errors = request_deletes(candidates)
+        raise_if_stalled(candidates, newly_requested, errors)
+        if monotonic() >= deadline:
+            names = ", ".join(name for _, name, _ in candidates)
+            detail = "; ".join(f"{uuid}: {error}" for uuid, error in errors.items())
+            suffix = f"; latest errors: {detail}" if detail else ""
+            raise CleanupError(f"Timed out waiting for GCNV ONTAP volumes to be deleted: {names}{suffix}")
+        sleep(poll_interval_seconds)
+
+    print(f"GCNV storage pool {storage_pool} has no non-root ONTAP volumes")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--location", required=True)
+    parser.add_argument("--storage-pool", required=True)
+    args = parser.parse_args()
+    cleanup(args.project, args.location, args.storage_pool)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wait_gcnv_ontap_ready.py
+++ b/scripts/wait_gcnv_ontap_ready.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Wait for the SVM root volume in a GCNV ONTAP-mode storage pool."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.delete_gcnv_ontap_volumes import (  # noqa: E402
+    CleanupError,
+    PoolAbsent,
+    TransientRequestError,
+    _access_token,
+    _all_volume_records,
+    build_ontap_api_url,
+)
+
+
+def _matching_root_volumes(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    roots = []
+    for record in records:
+        name = record.get("name")
+        nas = record.get("nas")
+        path = nas.get("path") if isinstance(nas, dict) else None
+        state = record.get("state")
+        volume_type = record.get("type")
+        if not isinstance(name, str):
+            raise CleanupError("every ONTAP volume must contain a string name")
+        if not isinstance(path, str):
+            raise CleanupError(f"ONTAP volume {name} must contain a string nas.path")
+        if not isinstance(state, str):
+            raise CleanupError(f"ONTAP volume {name} must contain a string state")
+        if not isinstance(volume_type, str):
+            raise CleanupError(f"ONTAP volume {name} must contain a string type")
+        if name.lower().endswith("_root") and path == "/" and state.lower() == "online" and volume_type.lower() == "rw":
+            roots.append(record)
+    return roots
+
+
+def wait_until_ready(
+    project: str,
+    location: str,
+    storage_pool: str,
+    *,
+    token: str | None = None,
+    opener: Callable[..., Any] = urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    timeout_seconds: float = 600,
+    poll_interval_seconds: float = 5,
+) -> None:
+    """Wait until exactly one online read-write SVM root volume exists."""
+    api_url = build_ontap_api_url(project, location, storage_pool)
+    access_token = token or _access_token()
+    query = urlencode(
+        {
+            "ontap_fields": "name,nas.path,is_svm_root,state,type",
+            "max_records": 10000,
+        }
+    )
+    list_url = f"{api_url}/storage/volumes?{query}"
+    deadline = monotonic() + timeout_seconds
+    last_status = "found 0 matching root volumes"
+
+    while True:
+        if monotonic() >= deadline:
+            raise CleanupError(f"Timed out waiting for GCNV ONTAP readiness: {last_status}")
+        try:
+            roots = _matching_root_volumes(
+                _all_volume_records(
+                    opener,
+                    access_token,
+                    api_url,
+                    list_url,
+                    first_not_found_is_absent=True,
+                    request_sleep=sleep,
+                    request_deadline=deadline,
+                    request_monotonic=monotonic,
+                )
+            )
+            if len(roots) == 1:
+                print(f"GCNV storage pool {storage_pool} ONTAP root volume is ready")
+                return
+            if len(roots) > 1:
+                raise CleanupError(f"found {len(roots)} matching root volumes in GCNV storage pool {storage_pool}")
+            last_status = "found 0 matching root volumes"
+        except (PoolAbsent, TransientRequestError) as error:
+            last_status = str(error)
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise CleanupError(f"Timed out waiting for GCNV ONTAP readiness: {last_status}")
+        sleep(min(poll_interval_seconds, remaining))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--location", required=True)
+    parser.add_argument("--storage-pool", required=True)
+    args = parser.parse_args()
+    wait_until_ready(args.project, args.location, args.storage_pool)
+
+
+if __name__ == "__main__":
+    main()

--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -44,3 +44,52 @@ resource "google_service_account_iam_binding" "gcr" {
     "serviceAccount:${var.project}.svc.id.goog[${var.namespaces.compute}/hephaestus]"
   ]
 }
+
+resource "google_service_account" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  account_id   = "${var.deploy_id}-gcnv"
+  display_name = "${var.deploy_id}-gcnv"
+}
+
+# ONTAP writes require a custom role.
+resource "google_project_iam_custom_role" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  project     = var.project
+  role_id     = replace("${var.deploy_id}_gcnv_trident", "-", "_")
+  title       = "${var.deploy_id} GCNV Trident"
+  description = "Least-privilege GCNV access for the Trident controller in ${var.deploy_id}"
+  permissions = [
+    "netapp.ontap.get",
+    "netapp.ontap.post",
+    "netapp.ontap.patch",
+    "netapp.ontap.delete",
+  ]
+}
+
+resource "google_project_iam_member" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  project = var.project
+  role    = google_project_iam_custom_role.gcnv[0].name
+  member  = "serviceAccount:${google_service_account.gcnv[0].email}"
+}
+
+resource "google_project_iam_member" "gcnv_viewer" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  project = var.project
+  role    = "roles/netapp.viewer"
+  member  = "serviceAccount:${google_service_account.gcnv[0].email}"
+}
+
+resource "google_service_account_iam_binding" "gcnv" {
+  count = var.storage.gcnv.enabled ? 1 : 0
+
+  service_account_id = google_service_account.gcnv[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "serviceAccount:${var.project}.svc.id.goog[${var.storage.gcnv.trident_namespace}/trident-controller]",
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,14 @@ variable "storage" {
     gcs = {
       force_destroy_on_deletion = Toogle to allow recursive deletion of all objects in the bucket. if 'false' terraform will NOT be able to delete non-empty buckets.
     }
+    gcnv = {
+      enabled = Provision a Google Cloud NetApp Volumes storage pool in ONTAP-mode (Trident GCNV backend)
+      pool_capacity_gib = GCNV storage pool capacity (GiB)
+      trident_namespace = Namespace containing the Trident controller service account
+      regional = If true, create a zone-redundant (regional) pool with two synchronous replicas across two zones; if false (default), a single-zone (zonal) pool.
+      primary_zone = Active zone for a regional pool. Required when regional is true.
+      replica_zone = Standby zone for a regional pool. Required when regional is true.
+    }
   EOF
 
   type = object({
@@ -77,10 +85,30 @@ variable "storage" {
     }), {}),
     gcs = optional(object({
       force_destroy_on_deletion = optional(bool, false)
+    }), {}),
+    gcnv = optional(object({
+      enabled           = optional(bool, false)
+      pool_capacity_gib = optional(number, 1024)
+      trident_namespace = optional(string, "trident")
+      regional          = optional(bool, false)
+      primary_zone      = optional(string)
+      replica_zone      = optional(string)
     }), {})
   })
 
   default = {}
+
+  validation {
+    condition = length([
+      for enabled in [
+        var.storage.filestore.enabled,
+        var.storage.nfs_instance.enabled,
+        var.storage.gcnv.enabled,
+      ] : enabled if enabled
+    ]) <= 1
+    error_message = "Only one shared storage backend can be enabled."
+  }
+
 }
 
 variable "managed_dns" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.4"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 5.0, < 8.0"
+      source = "hashicorp/google"
+      # ONTAP-mode fields require google >= 7.28.0.
+      version = ">= 7.28.0, < 8.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -13,5 +14,22 @@ terraform {
       source  = "hashicorp/google-beta"
       version = ">= 5.0, < 8.0"
     }
+    netapp-ontap = {
+      source  = "NetApp/netapp-ontap"
+      version = "2.7.0"
+    }
   }
+}
+
+provider "netapp-ontap" {
+  connection_profiles = [
+    {
+      name = var.deploy_id
+      google_netapp_unified_pool = {
+        project_id   = var.project
+        location     = local.gcnv_location
+        storage_pool = var.deploy_id
+      }
+    }
+  ]
 }


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/DOM-79156

Adds opt-in GCNV ONTAP-mode storage for Trident on GKE. The module provisions the storage pool and Private Service Access network, creates a least-privilege Workload Identity service account for the configured Trident namespace, and owns the NetApp ONTAP provider profile.

The module discovers the single SVM root volume, grants the cluster CIDR access through its NFS export policy, and exports the root volume and policy names consumed by platform-apps. Destroy cleanup is scoped to the exact deployment pool: it preserves the SVM root volume, unmounts and force-deletes Trident-created volumes, waits for ONTAP jobs, and fails closed on malformed or unreachable inventory. Filestore remains the default when GCNV is not enabled.